### PR TITLE
Fix action types

### DIFF
--- a/src/features/categorySelect/namespace.ts
+++ b/src/features/categorySelect/namespace.ts
@@ -1,37 +1,36 @@
 import { ICategoriesResponse } from 'shared/api/Api';
+import { IAction, IPlainAction } from 'shared/types/app';
 
-interface ICategory {
+export interface ICategory {
   uid: number;
   name: string;
   id: number;
 }
 
-interface ICommunication {
+export interface ICommunication {
   isRequesting: boolean;
   error: string;
 }
 
-interface IData {
+export interface IData {
   options: ICategory[];
   selected: number | null;
 }
 
-interface IReduxState {
+export interface IReduxState {
   communications: {
     categoriesFetching: ICommunication;
   };
   data: IData;
 }
 
-type Action =
-  { type: 'CATEGORY_SELECT:CATEGORY_SELECTED'; payload: number } |
-  { type: 'CATEGORY_SELECT:LOAD_CATEGORIES'; } |
-  { type: 'CATEGORY_SELECT:LOAD_CATEGORIES_COMPLETED'; payload: ICategoriesResponse; };
+export type IChooseCategoryAction = IAction<'CATEGORY_SELECT:CHOOSE_CATEGORY', number>;
+export type ILoadCategoriesAction = IPlainAction<'CATEGORY_SELECT:LOAD_CATEGORIES'>;
+export type ILoadCategoriesCompletedAction = IAction<'CATEGORY_SELECT:LOAD_CATEGORIES_COMPLETED', ICategoriesResponse>;
+export type ILoadCategoriesFailedAction = IAction<'CATEGORY_SELECT:LOAD_CATEGORIES_COMPLETED', string>;
 
-export {
-  IData,
-  IReduxState,
-  ICommunication,
-  ICategory,
-  Action,
-};
+export type CategorySelectAction =
+  | IChooseCategoryAction
+  | ILoadCategoriesAction
+  | ILoadCategoriesCompletedAction
+  | ILoadCategoriesFailedAction;

--- a/src/features/categorySelect/redux/actions/communication.ts
+++ b/src/features/categorySelect/redux/actions/communication.ts
@@ -1,17 +1,12 @@
-import { Action } from './../../namespace';
+import * as NS from './../../namespace';
 
-function loadCategories(): Action {
+export function loadCategories(): NS.ILoadCategoriesAction {
   return { type: 'CATEGORY_SELECT:LOAD_CATEGORIES' };
 }
 
-function chooseCategory(categoryUid: number): Action {
+export function chooseCategory(categoryUid: number): NS.IChooseCategoryAction {
   return {
-    type: 'CATEGORY_SELECT:CATEGORY_SELECTED',
+    type: 'CATEGORY_SELECT:CHOOSE_CATEGORY',
     payload: categoryUid,
   };
 }
-
-export {
-  loadCategories,
-  chooseCategory,
-};

--- a/src/features/categorySelect/redux/data/selectors.ts
+++ b/src/features/categorySelect/redux/data/selectors.ts
@@ -1,29 +1,23 @@
 import { createSelector } from 'reselect';
 import { IReduxState, ICategory, ICommunication } from '../../namespace';
 
-function selectCategories(state: IReduxState): ICategory[] {
+export function selectCategories(state: IReduxState): ICategory[] {
   return state.data.options;
 }
 
-function selectChosenCategory(state: IReduxState): number | null {
+export function selectChosenCategory(state: IReduxState): number | null {
   return state.data.selected;
 }
 
-const selectChosenCategoryObject = createSelector<IReduxState, ICategory[], number | null, ICategory | undefined>(
-  selectCategories,
-  selectChosenCategory,
-  (categories: ICategory[], uid: number | null) => {
-    return categories.find((category: ICategory) => category.uid === uid);
-  },
-);
+export const selectChosenCategoryObject =
+  createSelector<IReduxState, ICategory[], number | null, ICategory | undefined>(
+    selectCategories,
+    selectChosenCategory,
+    (categories: ICategory[], uid: number | null) => {
+      return categories.find((category: ICategory) => category.uid === uid);
+    },
+  );
 
-function selectCategoriesFetching(state: IReduxState): ICommunication {
+export function selectCategoriesFetching(state: IReduxState): ICommunication {
   return state.communications.categoriesFetching;
 }
-
-export {
-  selectCategories,
-  selectChosenCategory,
-  selectChosenCategoryObject,
-  selectCategoriesFetching,
-};

--- a/src/features/categorySelect/redux/reducers/index.ts
+++ b/src/features/categorySelect/redux/reducers/index.ts
@@ -1,38 +1,37 @@
 import { initialCommunicationState, initialDataState } from '../data/initial';
 import { Map, fromJS } from 'immutable';
-import { IAction } from 'shared/types/app';
-import { IReduxState, ICommunication, IData, Action } from '../../namespace';
+
+import { IReduxState, ICommunication, IData, CategorySelectAction } from '../../namespace';
 import { combineReducers, Reducer } from 'redux';
 
-function mainReducer(state: IData = initialDataState, action: Action): IData {
+function mainReducer(state: IData = initialDataState, action: CategorySelectAction): IData {
   const imState: Map<string, any> = fromJS(state);
 
   switch (action.type) {
-  case 'CATEGORY_SELECT:LOAD_CATEGORIES_COMPLETED':
-    // return { ...state, options: action.payload };
-    return imState.set('options', action.payload).toJS();
-  case ('CATEGORY_SELECT:CATEGORY_SELECTED'):
-    return imState.set('selected', action.payload).toJS();
-  default:
-    return state;
+    case 'CATEGORY_SELECT:LOAD_CATEGORIES_COMPLETED':
+      return imState.set('options', action.payload).toJS();
+    case 'CATEGORY_SELECT:CHOOSE_CATEGORY':
+      return imState.set('selected', action.payload).toJS();
+    default:
+      return state;
   }
 }
 
 function getCommunicationReducer(actionType: string) {
   return function communicationReducer(
     state: ICommunication = initialCommunicationState,
-    { type, payload }: IAction,
+    { type, payload }: any,
   ): ICommunication {
     const imState: Map<string, any> = fromJS(state);
 
     switch (type) {
-    case `CATEGORY_SELECT:${actionType}`:
-      return imState.set('isRequesting', true).set('error', '').toJS();
-    case `CATEGORY_SELECT:${actionType}_COMPLETED`:
-      return imState.set('isRequesting', false).toJS();
-    case `CATEGORY_SELECT:${actionType}_FAILED`:
-      return imState.set('isRequesting', false).set('error', payload).toJS();
-    default: return state;
+      case `CATEGORY_SELECT:${actionType}`:
+        return imState.set('isRequesting', true).set('error', '').toJS();
+      case `CATEGORY_SELECT:${actionType}_COMPLETED`:
+        return imState.set('isRequesting', false).toJS();
+      case `CATEGORY_SELECT:${actionType}_FAILED`:
+        return imState.set('isRequesting', false).set('error', payload).toJS();
+      default: return state;
     }
   };
 }

--- a/src/features/dynamicFields/namespace.ts
+++ b/src/features/dynamicFields/namespace.ts
@@ -1,20 +1,23 @@
 import { IGeosuggestOption } from 'shared/view/components/GenericLocationInput/GenericLocationInput';
+import { FieldValue } from 'shared/view/components/GenericInput/GenericInput';
+import { IAction } from 'shared/types/app';
+import { IFieldsResponse } from 'shared/api/Api';
 
-interface IFormProperties {
+export interface IFormProperties {
   [key: string]: string | number | IGeosuggestOption;
 }
 
-interface IFlatFormProperties {
+export interface IFlatFormProperties {
   [key: string]: string | number;
 }
 
-interface ILocationProperties {
+export interface ILocationProperties {
   [key: string]: { lat: number; lng: number; };
   from: { lat: number; lng: number; };
   to: { lat: number; lng: number; };
 }
 
-interface IField {
+export interface IField {
   type: 'string' | 'integer';
   component: 'text' | 'integer' | 'radio' | 'dropdown' | 'location' | 'date' | 'time';
   order: number;
@@ -29,14 +32,14 @@ interface IField {
   maxLength: number;
 }
 
-interface ISchema {
-  properties: {[key: string]: IField};
+export interface ISchema {
+  properties: { [key: string]: IField };
   required: string[];
   type: 'string';
   title: string;
 }
 
-interface IFields {
+export interface IFields {
   schema?: ISchema;
   id?: number;
   uid?: number;
@@ -44,12 +47,12 @@ interface IFields {
   name?: number;
 }
 
-interface ICommunication {
+export interface ICommunication {
   isRequesting: boolean;
   error: string;
 }
 
-interface IReduxState {
+export interface IReduxState {
   communications: {
     fetching: ICommunication;
   };
@@ -59,13 +62,18 @@ interface IReduxState {
   };
 }
 
-export {
-  IFormProperties,
-  IFlatFormProperties,
-  ILocationProperties,
-  ISchema,
-  IFields,
-  IField,
-  ICommunication,
-  IReduxState,
-};
+export type ILoadFieldsAction = IAction<'DYNAMIC_FIELDS:LOAD_FIELDS', number>;
+export type ILoadFieldsCompletedAction = IAction<'DYNAMIC_FIELDS:LOAD_FIELDS_COMPLETED', IFieldsResponse>;
+export type ILoadFieldsFailedAction = IAction<'DYNAMIC_FIELDS:LOAD_FIELDS_FAILED', string>;
+
+export type IChangeFieldValueAction = IAction<'DYNAMIC_FIELDS:CHANGE_FIELD_VALUE', IChangeFieldValueActionPayload>;
+export interface IChangeFieldValueActionPayload {
+  name: string;
+  value: FieldValue;
+}
+
+export type DynamicFieldsAction =
+  | ILoadFieldsAction
+  | ILoadFieldsCompletedAction
+  | ILoadFieldsFailedAction
+  | IChangeFieldValueAction;

--- a/src/features/dynamicFields/redux/actions/communication.ts
+++ b/src/features/dynamicFields/redux/actions/communication.ts
@@ -1,20 +1,15 @@
-import { IAction } from 'shared/types/app';
 import { IFieldsResponse } from 'shared/api/Api';
 
-function loadFields(uid: number): IAction {
+import * as NS from '../../namespace';
+
+export function loadFields(uid: number): NS.ILoadFieldsAction {
   return { type: 'DYNAMIC_FIELDS:LOAD_FIELDS', payload: uid };
 }
 
-function loadFieldsSuccessed(data: IFieldsResponse): IAction {
+export function loadFieldsCompleted(data: IFieldsResponse): NS.ILoadFieldsCompletedAction {
   return { type: 'DYNAMIC_FIELDS:LOAD_FIELDS_COMPLETED', payload: data };
 }
 
-function loadFieldsFailed(message: string): IAction {
+export function loadFieldsFailed(message: string): NS.ILoadFieldsFailedAction {
   return { type: 'DYNAMIC_FIELDS:LOAD_FIELDS_FAILED', payload: message };
 }
-
-export {
-  loadFields,
-  loadFieldsFailed,
-  loadFieldsSuccessed,
-};

--- a/src/features/dynamicFields/redux/actions/data.ts
+++ b/src/features/dynamicFields/redux/actions/data.ts
@@ -1,8 +1,6 @@
 import { FieldValue } from 'shared/view/components/GenericInput/GenericInput';
-import { IAction } from 'shared/types/app';
+import * as NS from '../../namespace';
 
-function changeFieldValue(name: string, value: FieldValue): IAction {
+export function changeFieldValue(name: string, value: FieldValue): NS.IChangeFieldValueAction {
   return { type: 'DYNAMIC_FIELDS:CHANGE_FIELD_VALUE', payload: { name, value } };
 }
-
-export { changeFieldValue };

--- a/src/features/dynamicFields/redux/actions/sagas.ts
+++ b/src/features/dynamicFields/redux/actions/sagas.ts
@@ -1,12 +1,15 @@
-import { IDependencies, IAction } from 'shared/types/app';
 import { SagaIterator } from 'redux-saga';
 import { call, put, takeLatest } from 'redux-saga/effects';
+
+import { IDependencies } from 'shared/types/app';
 import { IFieldsResponse } from 'shared/api/Api';
 import getErrorMsg from 'shared/helpers/getErrorMessage';
-import { loadFieldsSuccessed, loadFieldsFailed } from './communication';
+
+import { loadFieldsCompleted, loadFieldsFailed } from './communication';
+import { DynamicFieldsAction } from '../../namespace';
 
 function getSaga({ api }: IDependencies): () => SagaIterator {
-  function* executeLoadFields(action?: IAction) {
+  function* executeLoadFields(action?: DynamicFieldsAction) {
     if (!action) {
       return;
     }
@@ -14,7 +17,7 @@ function getSaga({ api }: IDependencies): () => SagaIterator {
     try {
       const uid = action.payload as number;
       const response: IFieldsResponse = yield call(api.loadFields, uid);
-      yield put(loadFieldsSuccessed(response));
+      yield put(loadFieldsCompleted(response));
     } catch (error) {
       const message = getErrorMsg(error);
       yield put(loadFieldsFailed(message));

--- a/src/features/dynamicFields/redux/reducers/index.ts
+++ b/src/features/dynamicFields/redux/reducers/index.ts
@@ -1,37 +1,36 @@
+// import { IPlainAction } from 'shared/types/app';
 import initialState from '../data/initial';
 import { Map, fromJS } from 'immutable';
-import { IAction } from 'shared/types/app';
-import { IReduxState } from '../../namespace';
+import { IReduxState, DynamicFieldsAction } from '../../namespace';
 
-function reducer(state: IReduxState = initialState, action: IAction): IReduxState {
+function reducer(state: IReduxState = initialState, action: DynamicFieldsAction): IReduxState {
   const imState: Map<string, any> = fromJS(state);
-
   switch (action.type) {
-  case ('DYNAMIC_FIELDS:LOAD_FIELDS'):
-    return imState
-      .setIn(['communications', 'fetching', 'isRequesting'], true)
-      .setIn(['data', 'fields', 'uid'], action.payload)
-      .setIn(['data', 'fields', 'values'], {})
-      .toJS();
-  case ('DYNAMIC_FIELDS:LOAD_FIELDS_COMPLETED'):
-    return imState
-      .setIn(['communications', 'fetching', 'isRequesting'], false)
-      .setIn(['communications', 'fetching', 'error'], '')
-      .setIn(['data', 'fields'], action.payload)
-      .toJS();
-  case ('DYNAMIC_FIELDS:LOAD_CATEGORIES_FAILED'):
-    return imState
-      .setIn(['communications', 'fetching', 'isRequesting'], false)
-      .setIn(['communications', 'fetching', 'error'], action.payload)
-      .toJS();
-  case 'DYNAMIC_FIELDS:CHANGE_FIELD_VALUE': {
-    interface IData { name: string; value: string; }
-    const payload = action.payload as IData;
-    return imState.setIn(['data', 'values', payload.name], payload.value).toJS();
-  }
-  default:
-    return state;
+    case 'DYNAMIC_FIELDS:LOAD_FIELDS':
+      return imState
+        .setIn(['communications', 'fetching', 'isRequesting'], true)
+        .setIn(['data', 'fields', 'uid'], action.payload)
+        .setIn(['data', 'fields', 'values'], {})
+        .toJS();
+    case 'DYNAMIC_FIELDS:LOAD_FIELDS_COMPLETED':
+      return imState
+        .setIn(['communications', 'fetching', 'isRequesting'], false)
+        .setIn(['communications', 'fetching', 'error'], '')
+        .setIn(['data', 'fields'], action.payload)
+        .toJS();
+    case 'DYNAMIC_FIELDS:LOAD_FIELDS_FAILED':
+      return imState
+        .setIn(['communications', 'fetching', 'isRequesting'], false)
+        .setIn(['communications', 'fetching', 'error'], action.payload)
+        .toJS();
+    case 'DYNAMIC_FIELDS:CHANGE_FIELD_VALUE': {
+      interface IData { name: string; value: string; }
+      const payload = action.payload as IData;
+      return imState.setIn(['data', 'values', payload.name], payload.value).toJS();
+    }
+    default:
+      return state;
   }
 }
 
-export default reducer;
+export default reducer as (state: IReduxState, action: any) => IReduxState;

--- a/src/features/dynamicFields/view/DynamicFields/DynamicFields.tsx
+++ b/src/features/dynamicFields/view/DynamicFields/DynamicFields.tsx
@@ -41,7 +41,7 @@ interface IDispatchProps {
 type Props = IDispatchProps & IStateProps & IOwnProps;
 
 interface IState {
-  values: {[key: string]: string | number | {[key: string]: any}};
+  values: { [key: string]: string | number | { [key: string]: any } };
   errors: string[];
 }
 
@@ -126,7 +126,7 @@ class DynamicFields extends React.Component<Props, IState> {
     const { fields } = this.props;
     if (fields && fields.schema && fields.schema.properties) {
       const requriedFields: string[] = fields.schema.required;
-      const properties: {[key: string]: IField} = fields.schema.properties;
+      const properties: { [key: string]: IField } = fields.schema.properties;
       const fieldsNode = Object
         .keys(properties)
         .filter((fieldName: string) => {

--- a/src/features/locationSelect/namespace.ts
+++ b/src/features/locationSelect/namespace.ts
@@ -1,27 +1,29 @@
-interface ICommunication {
+import { IPlainAction, IAction } from 'shared/types/app';
+
+export interface ICommunication {
   isRequesting: boolean;
   error: string;
 }
 
-interface IAreaResponse {
+export interface IAreaResponse {
   city: number;
   display_name: string;
   name: string;
   point: string;
 }
 
-interface ICityResponse {
+export interface ICityResponse {
   areas: IAreaResponse[];
   name: string;
   id: number;
 }
 
-interface IPoint {
+export interface IPoint {
   lat: number;
   lng: number;
 }
 
-interface IArea {
+export interface IArea {
   displayName: string;
   name: string;
   city: number;
@@ -29,13 +31,13 @@ interface IArea {
   id: number;
 }
 
-interface ICity {
+export interface ICity {
   areas: number[];
   name: string;
   id: number;
 }
 
-interface INormalizedCitiesResponse {
+export interface INormalizedCitiesResponse {
   result: number[];
   entities: {
     cities: IAreaEntities;
@@ -43,12 +45,22 @@ interface INormalizedCitiesResponse {
   };
 }
 
-interface IAreaEntities { [key: number]: IArea; }
-interface ICityEntities { [key: number]: ICity; }
-type SelectedLocation = null | { city: number, area: number, point: IPoint };
-type SelectedLocationData = null | { city: ICity; area: IArea, point: IPoint };
+export interface ILocation {
+  city: ICity;
+  area: IArea;
+  point: IPoint;
+}
 
-interface IReduxState {
+export interface ILocationCode {
+  city: number;
+  area: number;
+  point: IPoint;
+}
+
+export interface IAreaEntities { [key: number]: IArea; }
+export interface ICityEntities { [key: number]: ICity; }
+
+export interface IReduxState {
   communications: {
     citiesFetching: ICommunication;
   };
@@ -58,24 +70,31 @@ interface IReduxState {
       cities: ICityEntities;
     },
     citiesSet: number[],
-    selectedLocation: SelectedLocation;
+    selectedLocation?: ILocationCode;
   };
   ui: {
     showSelectedLocation: boolean;
   };
 }
 
-export {
-  ICommunication,
-  IReduxState,
-  IAreaResponse,
-  ICityResponse,
-  IPoint,
-  IArea,
-  ICity,
-  IAreaEntities,
-  ICityEntities,
-  INormalizedCitiesResponse,
-  SelectedLocationData,
-  SelectedLocation,
-};
+export type ILoadCitiesAction = IPlainAction<'LOCATION_SELECT:LOAD_CITIES'>;
+export type ILoadCitiesCompletedAction = IAction<'LOCATION_SELECT:LOAD_CITIES_COMPLETED', INormalizedCitiesResponse>;
+export type ILoadCitiesFailedAction = IPlainAction<'LOCATION_SELECT:LOAD_CITIES_FAILED'>;
+
+export type ISelectLocationByAreaIDAction
+  = IAction<'LOCATION_SELECT:SELECT_LOCATION_BY_AREA_ID', ISelectLocationByAreaIDActionPayload>;
+
+export interface ISelectLocationByAreaIDActionPayload {
+  location?: IAreaCode;
+  showOnMap: boolean;
+}
+export interface IAreaCode {
+  areaID: number;
+  point?: IPoint;
+}
+
+export type LocationSelectAction =
+  | ILoadCitiesAction
+  | ILoadCitiesCompletedAction
+  | ILoadCitiesFailedAction
+  | ISelectLocationByAreaIDAction;

--- a/src/features/locationSelect/redux/actions/communication.ts
+++ b/src/features/locationSelect/redux/actions/communication.ts
@@ -1,7 +1,3 @@
-function loadCities() {
+export function loadCities() {
   return { type: 'LOCATION_SELECT:LOAD_CITIES' };
 }
-
-export {
-  loadCities,
-};

--- a/src/features/locationSelect/redux/actions/data.ts
+++ b/src/features/locationSelect/redux/actions/data.ts
@@ -1,10 +1,7 @@
-import { IAction } from 'shared/types/app';
-import { IPoint } from '../../namespace';
+import * as NS from '../../namespace';
 
-function selectLocationByAreaId(location: {areaId: number, point: IPoint | null} | null, showOnMap: boolean): IAction {
-  return { type: 'LOCATION_SELECT:SELECT_LOCATION_BY_AREA_ID', payload: { location, showOnMap } };
+export function selectLocationByAreaId(
+  payload: NS.ISelectLocationByAreaIDActionPayload,
+): NS.ISelectLocationByAreaIDAction {
+  return { type: 'LOCATION_SELECT:SELECT_LOCATION_BY_AREA_ID', payload };
 }
-
-export {
-  selectLocationByAreaId,
-};

--- a/src/features/locationSelect/redux/data/initial.ts
+++ b/src/features/locationSelect/redux/data/initial.ts
@@ -13,7 +13,6 @@ const initialState: IReduxState = {
       cities: {},
     },
     citiesSet: [],
-    selectedLocation: null,
   },
   ui: {
     showSelectedLocation: false,

--- a/src/features/locationSelect/redux/data/selectors.ts
+++ b/src/features/locationSelect/redux/data/selectors.ts
@@ -1,10 +1,10 @@
-import { IReduxState, SelectedLocation, IArea, ICity } from '../../namespace';
+import { IReduxState, ILocationCode, IArea, ICity } from '../../namespace';
 
 function getFeatureState(state: any): IReduxState {
   return state.locationSelect;
 }
 
-function selectSelectedLocation(state: any): SelectedLocation {
+function selectSelectedLocation(state: any): ILocationCode | undefined {
   const ownState: IReduxState = getFeatureState(state);
   return ownState.data.selectedLocation;
 }

--- a/src/features/locationSelect/redux/reducers/index.ts
+++ b/src/features/locationSelect/redux/reducers/index.ts
@@ -1,42 +1,40 @@
 import initialState from '../data/initial';
 import { Map, fromJS } from 'immutable';
-import { IAction } from 'shared/types/app';
-import { IReduxState, IPoint, IArea, ICity, INormalizedCitiesResponse } from '../../namespace';
 
-function reducer(state: IReduxState = initialState, action: IAction): IReduxState {
+import { IReduxState, IPoint, IArea, ICity, INormalizedCitiesResponse, LocationSelectAction } from '../../namespace';
+
+function reducer(state: IReduxState = initialState, action: LocationSelectAction): IReduxState {
   const imState: Map<string, any> = fromJS(state);
 
   switch (action.type) {
-  case 'LOCATION_SELECT:LOAD_CITIES_SUCCESS': {
-    const data: INormalizedCitiesResponse = action.payload as INormalizedCitiesResponse;
-    return imState
-      .setIn(['data', 'entities'], data.entities)
-      .setIn(['data', 'citiesSet'], data.result)
-      .toJS();
-  }
-  case 'LOCATION_SELECT:SELECT_LOCATION_BY_AREA_ID': {
-    interface IPayload { location: { areaId: number, point: IPoint | null } | null; showOnMap: boolean; }
-    const payload = (action.payload as IPayload);
-    const showOnMap: boolean = (action.payload as IPayload).showOnMap;
-
-    if (payload.location) {
-      const areaId: number = payload.location.areaId;
-      const area: IArea = imState.getIn(['data', 'entities', 'areas', areaId.toString()]).toJS();
-      const city: ICity = imState.getIn(['data', 'entities', 'cities', area.city.toString()]).toJS();
-      const point: IPoint = payload.location.point ? payload.location.point : area.point;
+    case 'LOCATION_SELECT:LOAD_CITIES_COMPLETED': {
+      const data: INormalizedCitiesResponse = action.payload;
       return imState
-        .setIn(['data', 'selectedLocation'], { city: city.id, area: area.id, point })
-        .setIn(['ui', 'showSelectedLocation'], showOnMap)
-        .toJS();
-    } else {
-      return imState
-        .setIn(['ui', 'showSelectedLocation'], showOnMap)
-        .setIn(['data', 'selectedLocation'], null)
+        .setIn(['data', 'entities'], data.entities)
+        .setIn(['data', 'citiesSet'], data.result)
         .toJS();
     }
-  }
-  default:
-    return state;
+    case 'LOCATION_SELECT:SELECT_LOCATION_BY_AREA_ID': {
+      const { location, showOnMap } = action.payload;
+
+      if (location) {
+        const areaId: number = location.areaID;
+        const area: IArea = imState.getIn(['data', 'entities', 'areas', areaId.toString()]).toJS();
+        const city: ICity = imState.getIn(['data', 'entities', 'cities', area.city.toString()]).toJS();
+        const point: IPoint = location.point ? location.point : area.point;
+        return imState
+          .setIn(['data', 'selectedLocation'], { city: city.id, area: area.id, point })
+          .setIn(['ui', 'showSelectedLocation'], showOnMap)
+          .toJS();
+      } else {
+        return imState
+          .setIn(['ui', 'showSelectedLocation'], showOnMap)
+          .setIn(['data', 'selectedLocation'], null)
+          .toJS();
+      }
+    }
+    default:
+      return state;
   }
 }
 

--- a/src/features/locationSelect/view/containers/LocationSelect/LocationSelect.tsx
+++ b/src/features/locationSelect/view/containers/LocationSelect/LocationSelect.tsx
@@ -6,18 +6,18 @@ import { bindActionCreators } from 'redux';
 import { connect, Dispatch } from 'react-redux';
 import { bind } from 'decko';
 import { actions, selectors } from './../../../redux';
-import { SelectedLocationData, IReduxState, IArea, ICity } from '../../../namespace';
+import { ILocation, IReduxState, IArea, ICity } from '../../../namespace';
 import GoogleMap, { ILocation as MapLocation } from 'shared/view/components/GoogleMap/GoogleMap';
 import SelectInput from 'shared/view/elements/SelectInput/SelectInput';
 import './LocationSelect.scss';
 
 interface IOwnProps {
-  onChange?: (location: SelectedLocationData) => void;
+  onChange?: (location?: ILocation) => void;
 }
 
 interface IStateProps {
   options: Select.Option[];
-  selectedLocation: SelectedLocationData;
+  selectedLocation?: ILocation;
   showLocation: boolean;
 }
 
@@ -39,11 +39,11 @@ function mapState(state: any): IStateProps {
         return { label: area.displayName, value: area.id };
       },
     ),
-    selectedLocation: selectedLocation !== null ? {
+    selectedLocation: selectedLocation && {
       point: selectedLocation.point,
       area: selectors.selectAreaById(state, selectedLocation.area),
       city: selectors.selectCityById(state, selectedLocation.city),
-    } : null,
+    },
     showLocation: ownState.ui.showSelectedLocation,
   };
 }
@@ -75,7 +75,7 @@ class LocationSelect extends React.Component<Props> {
   public render() {
     interface IRenderData {
       options: Select.Option[];
-      selectedLocation: SelectedLocationData;
+      selectedLocation?: ILocation;
     }
 
     const b = this.b;
@@ -124,12 +124,14 @@ class LocationSelect extends React.Component<Props> {
   @bind
   private onSelectLocation(item: Select.Option | Select.Option[] | null) {
     if (!item || Array.isArray(item)) {
-      this.props.selectLocation(null, false);
+      this.props.selectLocation({ showOnMap: false });
     } else {
       this.props.selectLocation({
-        areaId: +(item.value || 0),
-        point: null,
-      }, true);
+        location: {
+          areaID: +(item.value || 0),
+        },
+        showOnMap: true,
+      });
     }
   }
 
@@ -142,10 +144,13 @@ class LocationSelect extends React.Component<Props> {
       areas.find((area: Select.Option) => area.label === selectedAreaName);
 
     if (selectedAreaOption) {
-      const point = location.point ? { lat: location.point.lat(), lng: location.point.lng() } : null;
-      this.props.selectLocation({ areaId: selectedAreaOption.value as number, point }, false);
+      const point = location.point ? { lat: location.point.lat(), lng: location.point.lng() } : undefined;
+      this.props.selectLocation({
+        location: { areaID: selectedAreaOption.value as number, point },
+        showOnMap: false,
+      });
     } else {
-      this.props.selectLocation(null, false);
+      this.props.selectLocation({ showOnMap: false });
     }
   }
 }

--- a/src/modules/OrderForm/namespace.ts
+++ b/src/modules/OrderForm/namespace.ts
@@ -1,6 +1,7 @@
 import { IFormProperties } from '../../features/dynamicFields/namespace';
+import { IPlainAction, IAction } from 'shared/types/app';
 
-interface IOrderFormRequest {
+export interface IOrderFormRequest {
   attributes: IFormProperties;
   notify: boolean;
   description: string;
@@ -12,45 +13,27 @@ interface IOrderFormRequest {
   coord_to_lat: number;
 }
 
-interface IOrderFormResponse {
+export interface IOrderFormResponse {
   message: string;
 }
 
-interface ICommunication {
+export interface ICommunication {
   isRequesting: boolean;
   error: string;
 }
 
-interface IReduxState {
+export interface IReduxState {
   communications: {
     saving: ICommunication;
   };
   data: { message: string; } | null;
 }
 
-interface ISaveFields {
-  type: 'HOME_MODULE:SAVE_FIELDS';
-}
+export type ISaveFieldsAction = IPlainAction<'ORDER_FORM_MODULE:SAVE_FIELDS'>;
+export type ISaveFieldsCompletedAction = IAction<'ORDER_FORM_MODULE:SAVE_FIELDS_COMPLETED', IOrderFormResponse>;
+export type ISaveFieldsFailedAction = IAction<'ORDER_FORM_MODULE:SAVE_FIELDS_FAILED', string>;
 
-interface ISaveFieldsSuccess {
-  type: 'HOME_MODULE:SAVE_FIELDS_SUCCESS';
-  payload: IOrderFormResponse;
-}
-
-interface ISaveFieldsFail {
-  type: 'HOME_MODULE:SAVE_FIELDS_FAIL';
-  payload: string;
-}
-
-type Action = ISaveFields | ISaveFieldsSuccess | ISaveFieldsFail;
-
-export {
-  IOrderFormRequest,
-  IOrderFormResponse,
-  ICommunication,
-  IReduxState,
-  ISaveFields,
-  ISaveFieldsSuccess,
-  ISaveFieldsFail,
-  Action,
-};
+export type OrderFormAction =
+  | ISaveFieldsAction
+  | ISaveFieldsCompletedAction
+  | ISaveFieldsFailedAction;

--- a/src/modules/OrderForm/redux/actions/communication.ts
+++ b/src/modules/OrderForm/redux/actions/communication.ts
@@ -1,27 +1,21 @@
-import { IOrderFormResponse, ISaveFields, ISaveFieldsSuccess, ISaveFieldsFail } from '../../namespace';
+import * as NS from '../../namespace';
 
-function saveFields(): ISaveFields {
+export function saveFields(): NS.ISaveFieldsAction {
   return {
-    type: 'HOME_MODULE:SAVE_FIELDS',
+    type: 'ORDER_FORM_MODULE:SAVE_FIELDS',
   };
 }
 
-function saveFieldsSuccess(response: IOrderFormResponse): ISaveFieldsSuccess {
+export function saveFieldsCompleted(response: NS.IOrderFormResponse): NS.ISaveFieldsCompletedAction {
   return {
-    type: 'HOME_MODULE:SAVE_FIELDS_SUCCESS',
+    type: 'ORDER_FORM_MODULE:SAVE_FIELDS_COMPLETED',
     payload: response,
   };
 }
 
-function saveFieldsFail(error: string): ISaveFieldsFail {
+export function saveFieldsFail(error: string): NS.ISaveFieldsFailedAction {
   return {
-    type: 'HOME_MODULE:SAVE_FIELDS_FAIL',
+    type: 'ORDER_FORM_MODULE:SAVE_FIELDS_FAILED',
     payload: error,
   };
 }
-
-export {
-  saveFields,
-  saveFieldsSuccess,
-  saveFieldsFail,
-};

--- a/src/modules/OrderForm/redux/reducers/index.ts
+++ b/src/modules/OrderForm/redux/reducers/index.ts
@@ -1,31 +1,30 @@
 import initialState from '../initial';
 import { Map, fromJS } from 'immutable';
-import { IAction } from 'shared/types/app';
-import { IReduxState } from '../../namespace';
+import { IReduxState, OrderFormAction } from '../../namespace';
 
-function reducer(state: IReduxState = initialState, action: IAction): IReduxState {
+function reducer(state: IReduxState = initialState, action: OrderFormAction): IReduxState {
   const imState: Map<string, any> = fromJS(state);
 
   switch (action.type) {
-  case 'HOME_MODULE:SAVE_FIELDS':
-    return imState
-      .setIn(['communications', 'saving', 'isRequesting'], true)
-      .setIn(['data'], null)
-      .toJS();
-  case 'HOME_MODULE:SAVE_FIELDS_SUCCESS':
-    return imState
-      .setIn(['communications', 'saving', 'isRequesting'], false)
-      .setIn(['communications', 'saving', 'error'], '')
-      .setIn(['data'], action.payload)
-      .toJS();
-  case 'HOME_MODULE:SAVE_FIELDS_FAIL':
-    return imState
-      .setIn(['communications', 'saving', 'isRequesting'], false)
-      .setIn(['communications', 'saving', 'error'], action.payload)
-      .setIn(['data'], null)
-      .toJS();
-  default:
-    return state;
+    case 'ORDER_FORM_MODULE:SAVE_FIELDS':
+      return imState
+        .setIn(['communications', 'saving', 'isRequesting'], true)
+        .setIn(['data'], null)
+        .toJS();
+    case 'ORDER_FORM_MODULE:SAVE_FIELDS_COMPLETED':
+      return imState
+        .setIn(['communications', 'saving', 'isRequesting'], false)
+        .setIn(['communications', 'saving', 'error'], '')
+        .setIn(['data'], action.payload)
+        .toJS();
+    case 'ORDER_FORM_MODULE:SAVE_FIELDS_FAILED':
+      return imState
+        .setIn(['communications', 'saving', 'isRequesting'], false)
+        .setIn(['communications', 'saving', 'error'], action.payload)
+        .setIn(['data'], null)
+        .toJS();
+    default:
+      return state;
   }
 }
 

--- a/src/modules/OrderForm/view/Layout/Layout.tsx
+++ b/src/modules/OrderForm/view/Layout/Layout.tsx
@@ -26,7 +26,7 @@ interface IStateProps {
 
 interface IState {
   categoryUid?: number;
-  location?: locationSelectFeature.Namespace.SelectedLocationData;
+  location?: locationSelectFeature.Namespace.ILocation;
   dynamicFields: {
     [key: string]: {
       value: FieldValue,
@@ -95,7 +95,7 @@ class OrderFormLayout extends React.Component<IProps, IState> {
   }
 
   @bind
-  private onLocationSelected(location: locationSelectFeature.Namespace.SelectedLocationData): void {
+  private onLocationSelected(location?: locationSelectFeature.Namespace.ILocation): void {
     this.setState({
       ...this.state,
       location,

--- a/src/shared/helpers/redux/communication/init.ts
+++ b/src/shared/helpers/redux/communication/init.ts
@@ -4,7 +4,7 @@ export const initialCommunicationField: ICommunicationState = { isRequesting: fa
 
 export function initCommunicationFields<S>(
   fieldNames: Array<keyof S>,
-): { [P in keyof S]: ICommunicationState } {
+): {[P in keyof S]: ICommunicationState } {
   return fieldNames.reduce((communicationFields, fieldName) => ({
     ...communicationFields,
     [fieldName]: initialCommunicationField,

--- a/src/shared/helpers/redux/communication/makeCommunicationActionCreators.ts
+++ b/src/shared/helpers/redux/communication/makeCommunicationActionCreators.ts
@@ -1,7 +1,10 @@
 import { IPlainAction, IAction, IFailAction, IFailActionWithPayload } from '../namespace';
 
-type NullaryAC<A extends IPlainAction> = () => A;
-type UnaryAC<A extends IAction> = (payload: A['payload']) => A;
+type IGenericPlainAction = IPlainAction<string>;
+type IGenericAction = IAction<string, any>;
+
+type NullaryAC<A extends IGenericPlainAction> = () => A;
+type UnaryAC<A extends IGenericAction> = (payload: A['payload']) => A;
 
 type NullaryFailedAC<A extends IFailAction> = (error: A['error']) => A;
 type UnaryFailedAC<A extends IFailActionWithPayload> = (error: A['error'], payload: A['payload']) => A;
@@ -13,44 +16,50 @@ interface ICommunicationActionCreators<E, C, F> {
 }
 
 function makeCommunicationActionCreators<
-  E extends IAction, C extends IAction, F extends IFailActionWithPayload
+  E extends IGenericAction, C extends IGenericAction, F extends IFailActionWithPayload
   >(
   executeType: E['type'], completeType: C['type'], failType: F['type'],
 ): ICommunicationActionCreators<UnaryAC<E>, UnaryAC<C>, UnaryFailedAC<F>>;
 
 function makeCommunicationActionCreators<
-  E extends IAction, C extends IAction, F extends IFailAction
+  E extends IGenericAction, C extends IGenericAction, F extends IFailAction
   >(
   executeType: E['type'], completeType: C['type'], failType: F['type'],
 ): ICommunicationActionCreators<UnaryAC<E>, UnaryAC<C>, NullaryFailedAC<F>>;
 
 function makeCommunicationActionCreators<
-  E extends IAction, C extends IPlainAction, F extends IFailActionWithPayload
+  E extends IGenericAction, C extends IGenericPlainAction, F extends IFailActionWithPayload
   >(
   executeType: E['type'], completeType: C['type'], failType: F['type'],
 ): ICommunicationActionCreators<UnaryAC<E>, NullaryAC<C>, UnaryFailedAC<F>>;
 
-function makeCommunicationActionCreators<E extends IAction, C extends IPlainAction, F extends IFailAction>(
+function makeCommunicationActionCreators<
+  E extends IGenericAction, C extends IGenericPlainAction, F extends IFailAction
+  >(
   executeType: E['type'], completeType: C['type'], failType: F['type'],
 ): ICommunicationActionCreators<UnaryAC<E>, NullaryAC<C>, NullaryFailedAC<F>>;
 
 function makeCommunicationActionCreators<
-  E extends IPlainAction, C extends IAction, F extends IFailActionWithPayload
+  E extends IGenericPlainAction, C extends IGenericAction, F extends IFailActionWithPayload
   >(
   executeType: E['type'], completeType: C['type'], failType: F['type'],
 ): ICommunicationActionCreators<NullaryAC<E>, UnaryAC<C>, UnaryFailedAC<F>>;
 
-function makeCommunicationActionCreators<E extends IPlainAction, C extends IAction, F extends IFailAction>(
+function makeCommunicationActionCreators<
+  E extends IGenericPlainAction, C extends IGenericAction, F extends IFailAction
+  >(
   executeType: E['type'], completeType: C['type'], failType: F['type'],
 ): ICommunicationActionCreators<NullaryAC<E>, UnaryAC<C>, NullaryFailedAC<F>>;
 
 function makeCommunicationActionCreators<
-  E extends IPlainAction, C extends IPlainAction, F extends IFailActionWithPayload
+  E extends IGenericPlainAction, C extends IGenericPlainAction, F extends IFailActionWithPayload
   >(
   executeType: E['type'], completeType: C['type'], failType: F['type'],
 ): ICommunicationActionCreators<NullaryAC<E>, NullaryAC<C>, UnaryFailedAC<F>>;
 
-function makeCommunicationActionCreators<E extends IPlainAction, C extends IPlainAction, F extends IFailAction>(
+function makeCommunicationActionCreators<
+  E extends IGenericPlainAction, C extends IGenericPlainAction, F extends IFailAction
+  >(
   executeType: E['type'], completeType: C['type'], failType: F['type'],
 ): ICommunicationActionCreators<NullaryAC<E>, NullaryAC<C>, NullaryFailedAC<F>>;
 

--- a/src/shared/helpers/redux/communication/makeCommunicationActionCreators.ts
+++ b/src/shared/helpers/redux/communication/makeCommunicationActionCreators.ts
@@ -1,7 +1,7 @@
-import { IAction, IActionWithPayload, IFailAction, IFailActionWithPayload } from '../namespace';
+import { IPlainAction, IAction, IFailAction, IFailActionWithPayload } from '../namespace';
 
-type NullaryAC<A extends IAction> = () => A;
-type UnaryAC<A extends IActionWithPayload> = (payload: A['payload']) => A;
+type NullaryAC<A extends IPlainAction> = () => A;
+type UnaryAC<A extends IAction> = (payload: A['payload']) => A;
 
 type NullaryFailedAC<A extends IFailAction> = (error: A['error']) => A;
 type UnaryFailedAC<A extends IFailActionWithPayload> = (error: A['error'], payload: A['payload']) => A;
@@ -13,42 +13,44 @@ interface ICommunicationActionCreators<E, C, F> {
 }
 
 function makeCommunicationActionCreators<
-  E extends IActionWithPayload, C extends IActionWithPayload, F extends IFailActionWithPayload
->(
+  E extends IAction, C extends IAction, F extends IFailActionWithPayload
+  >(
   executeType: E['type'], completeType: C['type'], failType: F['type'],
 ): ICommunicationActionCreators<UnaryAC<E>, UnaryAC<C>, UnaryFailedAC<F>>;
 
 function makeCommunicationActionCreators<
-  E extends IActionWithPayload, C extends IActionWithPayload, F extends IFailAction
->(
+  E extends IAction, C extends IAction, F extends IFailAction
+  >(
   executeType: E['type'], completeType: C['type'], failType: F['type'],
 ): ICommunicationActionCreators<UnaryAC<E>, UnaryAC<C>, NullaryFailedAC<F>>;
 
 function makeCommunicationActionCreators<
-  E extends IActionWithPayload, C extends IAction, F extends IFailActionWithPayload
->(
+  E extends IAction, C extends IPlainAction, F extends IFailActionWithPayload
+  >(
   executeType: E['type'], completeType: C['type'], failType: F['type'],
 ): ICommunicationActionCreators<UnaryAC<E>, NullaryAC<C>, UnaryFailedAC<F>>;
 
-function makeCommunicationActionCreators<E extends IActionWithPayload, C extends IAction, F extends IFailAction>(
+function makeCommunicationActionCreators<E extends IAction, C extends IPlainAction, F extends IFailAction>(
   executeType: E['type'], completeType: C['type'], failType: F['type'],
 ): ICommunicationActionCreators<UnaryAC<E>, NullaryAC<C>, NullaryFailedAC<F>>;
 
 function makeCommunicationActionCreators<
-  E extends IAction, C extends IActionWithPayload, F extends IFailActionWithPayload
->(
+  E extends IPlainAction, C extends IAction, F extends IFailActionWithPayload
+  >(
   executeType: E['type'], completeType: C['type'], failType: F['type'],
 ): ICommunicationActionCreators<NullaryAC<E>, UnaryAC<C>, UnaryFailedAC<F>>;
 
-function makeCommunicationActionCreators<E extends IAction, C extends IActionWithPayload, F extends IFailAction>(
+function makeCommunicationActionCreators<E extends IPlainAction, C extends IAction, F extends IFailAction>(
   executeType: E['type'], completeType: C['type'], failType: F['type'],
 ): ICommunicationActionCreators<NullaryAC<E>, UnaryAC<C>, NullaryFailedAC<F>>;
 
-function makeCommunicationActionCreators<E extends IAction, C extends IAction, F extends IFailActionWithPayload>(
+function makeCommunicationActionCreators<
+  E extends IPlainAction, C extends IPlainAction, F extends IFailActionWithPayload
+  >(
   executeType: E['type'], completeType: C['type'], failType: F['type'],
 ): ICommunicationActionCreators<NullaryAC<E>, NullaryAC<C>, UnaryFailedAC<F>>;
 
-function makeCommunicationActionCreators<E extends IAction, C extends IAction, F extends IFailAction>(
+function makeCommunicationActionCreators<E extends IPlainAction, C extends IPlainAction, F extends IFailAction>(
   executeType: E['type'], completeType: C['type'], failType: F['type'],
 ): ICommunicationActionCreators<NullaryAC<E>, NullaryAC<C>, NullaryFailedAC<F>>;
 

--- a/src/shared/helpers/redux/communication/makeCommunicationReducer.ts
+++ b/src/shared/helpers/redux/communication/makeCommunicationReducer.ts
@@ -1,16 +1,16 @@
 import { ICommunicationState, IPlainAction, IProtect, IFailAction } from '../namespace';
 
 export default function makeCommunicationReducer<
-  E extends IPlainAction = IProtect,
-  C extends IPlainAction = IProtect,
+  E extends IPlainAction<string> = IProtect,
+  C extends IPlainAction<string> = IProtect,
   F extends IFailAction = IProtect
   >(
   executeType: E['type'],
   completedType: C['type'],
   failedType: F['type'],
   initial: ICommunicationState<F['error']>,
-): (state: ICommunicationState<F['error']>, action: IPlainAction) => ICommunicationState<F['error']> {
-  return (state: ICommunicationState<F['error']> = initial, action: IPlainAction) => {
+): (state: ICommunicationState<F['error']>, action: IPlainAction<string>) => ICommunicationState<F['error']> {
+  return (state: ICommunicationState<F['error']> = initial, action: IPlainAction<string>) => {
     switch (action.type) {
       case executeType: return { error: '', isRequesting: true };
       case completedType: return { error: '', isRequesting: false };

--- a/src/shared/helpers/redux/communication/makeCommunicationReducer.ts
+++ b/src/shared/helpers/redux/communication/makeCommunicationReducer.ts
@@ -1,16 +1,16 @@
-import { ICommunicationState, IAction, IProtect, IFailAction } from '../namespace';
+import { ICommunicationState, IPlainAction, IProtect, IFailAction } from '../namespace';
 
 export default function makeCommunicationReducer<
-  E extends IAction = IProtect,
-  C extends IAction = IProtect,
+  E extends IPlainAction = IProtect,
+  C extends IPlainAction = IProtect,
   F extends IFailAction = IProtect
->(
+  >(
   executeType: E['type'],
   completedType: C['type'],
   failedType: F['type'],
   initial: ICommunicationState<F['error']>,
-): (state: ICommunicationState<F['error']>, action: IAction) => ICommunicationState<F['error']> {
-  return (state: ICommunicationState<F['error']> = initial, action: IAction) => {
+): (state: ICommunicationState<F['error']>, action: IPlainAction) => ICommunicationState<F['error']> {
+  return (state: ICommunicationState<F['error']> = initial, action: IPlainAction) => {
     switch (action.type) {
       case executeType: return { error: '', isRequesting: true };
       case completedType: return { error: '', isRequesting: false };

--- a/src/shared/helpers/redux/field/makeEditArrayFieldReducer.ts
+++ b/src/shared/helpers/redux/field/makeEditArrayFieldReducer.ts
@@ -1,18 +1,18 @@
 import { Reducer } from 'redux';
 
-import { IActionWithPayload, IReduxField, Validator } from '../namespace';
+import { IAction, IReduxField, Validator } from '../namespace';
 
 type ActionType<T> = ActionAdd<T> | ActionRemove | ActionUpdate<T>;
 
-type ActionAdd<T> = IActionWithPayload<T>;
+type ActionAdd<T> = IAction<T>;
 
-type ActionRemove = IActionWithPayload<number>;
+type ActionRemove = IAction<number>;
 
-type ActionUpdate<T> = IActionWithPayload<{ index: number; item: T }>;
+type ActionUpdate<T> = IAction<{ index: number; item: T }>;
 
 export default function makeArrayFieldReducer<
   A extends ActionAdd<T>, R extends ActionRemove, U extends ActionUpdate<T>, T
->(
+  >(
   addType: A['type'],
   removeType: R['type'],
   updateType: U['type'],

--- a/src/shared/helpers/redux/field/makeEditArrayFieldReducer.ts
+++ b/src/shared/helpers/redux/field/makeEditArrayFieldReducer.ts
@@ -2,33 +2,40 @@ import { Reducer } from 'redux';
 
 import { IAction, IReduxField, Validator } from '../namespace';
 
-type ActionType<T> = ActionAdd<T> | ActionRemove | ActionUpdate<T>;
+type ActionType<AT, RT, UT, UPI>
+  = IAddAction<AT> | IRemoveAction<RT> | IUpdateAction<UT, UPI>;
 
-type ActionAdd<T> = IAction<T>;
+type IAddAction<T> = IAction<T, any>;
 
-type ActionRemove = IAction<number>;
+type IRemoveAction<T> = IAction<T, number>;
 
-type ActionUpdate<T> = IAction<{ index: number; item: T }>;
+interface IUpdatePayload<T> {
+  index: number;
+  item: T;
+}
 
-export default function makeArrayFieldReducer<
-  A extends ActionAdd<T>, R extends ActionRemove, U extends ActionUpdate<T>, T
-  >(
-  addType: A['type'],
-  removeType: R['type'],
-  updateType: U['type'],
+type IUpdateAction<T, PI> = IAction<T, IUpdatePayload<PI>>;
+
+export default function makeArrayFieldReducer<AT, UT, RT, T>(
+  addType: AT,
+  removeType: RT,
+  updateType: UT,
   initial: IReduxField<T[]>,
   validator?: Validator<T[]>,
 ): Reducer<IReduxField<T[]>> {
-  return function arrayFieldReducer(state: IReduxField<T[]> = initial, action: ActionType<T>): IReduxField<T[]> {
+  return function arrayFieldReducer(
+    state: IReduxField<T[]> = initial, action: ActionType<AT, RT, UT, T>,
+  ): IReduxField<T[]> {
     switch (action.type) {
       case addType: {
-        const nextValue = [...state.value, action.payload as T];
+
+        const nextValue = [...state.value, action.payload];
         const error = validator ? validator(nextValue, state.value) : '';
 
         return { ...state, error, value: nextValue };
       }
       case removeType: {
-        const payload = action.payload as ActionRemove['payload'];
+        const payload = action.payload as IRemoveAction<RT>['payload'];
         const nextValue = [
           ...state.value.slice(0, payload),
           ...state.value.slice(payload + 1),
@@ -38,7 +45,7 @@ export default function makeArrayFieldReducer<
         return { ...state, error, value: nextValue };
       }
       case updateType: {
-        const { index, item } = action.payload as { index: number; item: T };
+        const { index, item } = action.payload as IUpdatePayload<T>;
         const nextValue = [...state.value.slice(0, index), item, ...state.value.slice(index + 1)];
         const error = validator ? validator(nextValue, state.value) : '';
 

--- a/src/shared/helpers/redux/field/makeEditFieldsReducer.ts
+++ b/src/shared/helpers/redux/field/makeEditFieldsReducer.ts
@@ -1,9 +1,9 @@
-import { IActionWithPayload, Validator, FieldsState } from '../namespace';
+import { IAction, Validator, FieldsState } from '../namespace';
 import { Reducer } from 'redux';
 
-type Validators<S> = Partial<{ [K in keyof S]: Validator<S[K]> }>;
+type Validators<S> = Partial<{[K in keyof S]: Validator<S[K]> }>;
 
-type EditFieldsReducerAction<F = string> = IActionWithPayload<string, { field: F, value: any, error?: string }>;
+type EditFieldsReducerAction<F = string> = IAction<string, { field: F, value: any, error?: string }>;
 
 function makeEditFieldsReducer<A extends EditFieldsReducerAction<A['payload']['field']>>(actionType: A['type']) {
   type Field = A['payload']['field'];

--- a/src/shared/helpers/redux/makeResetStateReducer.ts
+++ b/src/shared/helpers/redux/makeResetStateReducer.ts
@@ -1,5 +1,5 @@
-import { IAction } from './namespace';
+import { IPlainAction } from './namespace';
 
-export default function makeResetStateReducer<A extends IAction, S>(type: A['type'], initialState: S) {
+export default function makeResetStateReducer<A extends IPlainAction, S>(type: A['type'], initialState: S) {
   return (state: S, action: A) => action.type === type ? initialState : state;
 }

--- a/src/shared/helpers/redux/makeResetStateReducer.ts
+++ b/src/shared/helpers/redux/makeResetStateReducer.ts
@@ -1,5 +1,5 @@
 import { IPlainAction } from './namespace';
 
-export default function makeResetStateReducer<A extends IPlainAction, S>(type: A['type'], initialState: S) {
+export default function makeResetStateReducer<A extends IPlainAction<string>, S>(type: A['type'], initialState: S) {
   return (state: S, action: A) => action.type === type ? initialState : state;
 }

--- a/src/shared/helpers/redux/makeToucheFieldsReducer.ts
+++ b/src/shared/helpers/redux/makeToucheFieldsReducer.ts
@@ -1,7 +1,7 @@
 import { Reducer } from 'redux';
-import { IActionWithPayload, FieldsState } from './namespace';
+import { IAction, FieldsState } from './namespace';
 
-type ToucheFieldAction<F extends string> = IActionWithPayload<string, F>;
+type ToucheFieldAction<F extends string> = IAction<string, F>;
 
 function makeToucheFieldsReducer<A extends ToucheFieldAction<A['payload']>>(actionName: A['type']) {
   return <T extends FieldsState<A['payload']>>(initial: T) => {

--- a/src/shared/helpers/redux/namespace.ts
+++ b/src/shared/helpers/redux/namespace.ts
@@ -1,14 +1,14 @@
 import { Reducer } from 'redux';
 
-export interface IAction<T = string> {
+export interface IPlainAction<T = string> {
   type: T;
 }
 
-export interface IActionWithPayload<A = string, P = any> extends IAction<A> {
+export interface IAction<A = string, P = any> extends IPlainAction<A> {
   payload: P;
 }
 
-export interface IFailAction<T = any> extends IAction {
+export interface IFailAction<T = any> extends IPlainAction {
   error: T;
 }
 
@@ -37,7 +37,7 @@ export type FieldsState<F extends string> = {
 
 export type Validator<S> = (nextState: S, prevState: S) => string;
 
-export interface IEditFieldAction<T = any, E = string> extends IAction {
+export interface IEditFieldAction<T = any, E = string> extends IPlainAction {
   payload: IReduxField<T, E>;
 }
 

--- a/src/shared/helpers/redux/namespace.ts
+++ b/src/shared/helpers/redux/namespace.ts
@@ -1,14 +1,14 @@
 import { Reducer } from 'redux';
 
-export interface IPlainAction<T = string> {
+export interface IPlainAction<T> {
   type: T;
 }
 
-export interface IAction<A = string, P = any> extends IPlainAction<A> {
+export interface IAction<T, P> extends IPlainAction<T> {
   payload: P;
 }
 
-export interface IFailAction<T = any> extends IPlainAction {
+export interface IFailAction<T = any> extends IPlainAction<string> {
   error: T;
 }
 
@@ -37,7 +37,7 @@ export type FieldsState<F extends string> = {
 
 export type Validator<S> = (nextState: S, prevState: S) => string;
 
-export interface IEditFieldAction<T = any, E = string> extends IPlainAction {
+export interface IEditFieldAction<T = any, E = string> extends IPlainAction<string> {
   payload: IReduxField<T, E>;
 }
 

--- a/src/shared/types/app.ts
+++ b/src/shared/types/app.ts
@@ -53,6 +53,26 @@ interface IDependencies {
   api: Api;
 }
 
+// interface IPlainAction<T> {
+//   type: T;
+// }
+
+// interface IAction<T, P> extends IPlainAction<T> {
+//   payload: P;
+// }
+
+// interface IActionMeta {
+//   updatesSubtitles: boolean;
+// }
+
+// interface IMetaAction<T, P, M> extends IAction<T, P> {
+//   meta: M;
+// }
+
+// export interface IUpdatingSubtitleActionMeta extends IActionMeta {
+//   updatesSubtitles: true;
+// }
+
 interface IAction {
   payload?: { [key: string]: any } | number | string | null;
   type: string;
@@ -73,5 +93,7 @@ interface IModuleEntryData {
 
 type RootSaga = (deps: IDependencies) => () => SagaIterator;
 
-export { Module, IReducerData, IAction, IDependencies, IAppReduxState, IModuleEntryData };
+// export { IPlainAction, IAction, IMetaAction };
+export { IAction };
+export { Module, IReducerData, IDependencies, IAppReduxState, IModuleEntryData };
 export { RootSaga };

--- a/src/shared/types/app.ts
+++ b/src/shared/types/app.ts
@@ -8,7 +8,7 @@ import { Namespace as LocationSelectNamespace } from 'features/locationSelect';
 import { Namespace as DynamicFieldsNamespace } from 'features/dynamicFields';
 import { Namespace as HomeModuleNamespace } from '../../modules/OrderForm/OrderForm';
 
-abstract class Module<S, C> {
+export abstract class Module<S, C> {
   public components?: C; // available componens to pass in other modules
 
   protected _store: Store<IAppReduxState> | null = null;
@@ -42,58 +42,30 @@ abstract class Module<S, C> {
   }
 }
 
-type OnConnectRequestHandler = (reducers: Array<IReducerData<any>>, sagas: RootSaga[]) => void;
+export type OnConnectRequestHandler = (reducers: Array<IReducerData<any>>, sagas: RootSaga[]) => void;
 
-interface IReducerData<S> {
+export interface IReducerData<S> {
   name: string;
   reducer: Reducer<S>;
 }
 
-interface IDependencies {
+export interface IDependencies {
   api: Api;
 }
 
-// interface IPlainAction<T> {
-//   type: T;
-// }
-
-// interface IAction<T, P> extends IPlainAction<T> {
-//   payload: P;
-// }
-
-// interface IActionMeta {
-//   updatesSubtitles: boolean;
-// }
-
-// interface IMetaAction<T, P, M> extends IAction<T, P> {
-//   meta: M;
-// }
-
-// export interface IUpdatingSubtitleActionMeta extends IActionMeta {
-//   updatesSubtitles: true;
-// }
-
-interface IAction {
-  payload?: { [key: string]: any } | number | string | null;
-  type: string;
-}
-
-interface IAppReduxState {
+export interface IAppReduxState {
   categorySelect: CategorySelectNamespace.IReduxState;
   locationSelect: LocationSelectNamespace.IReduxState;
   dynamicFields: DynamicFieldsNamespace.IReduxState;
   orderForm: HomeModuleNamespace.IReduxState;
 }
 
-interface IModuleEntryData {
+export interface IModuleEntryData {
   component: React.ComponentClass<any> | React.StatelessComponent<any>;
   reducers: Array<IReducerData<any>>;
   sagas: RootSaga[];
 }
 
-type RootSaga = (deps: IDependencies) => () => SagaIterator;
+export type RootSaga = (deps: IDependencies) => () => SagaIterator;
 
-// export { IPlainAction, IAction, IMetaAction };
-export { IAction };
-export { Module, IReducerData, IDependencies, IAppReduxState, IModuleEntryData };
-export { RootSaga };
+export * from '../helpers/redux/namespace';


### PR DESCRIPTION
- Изменил имена `IAction` -> `IPlainAction` `IActionWithPayload` -> `IAction`. Так короче, экшн с пэйлоадом используется чаще того который без пэйлоада.
- Убрал типы по умолчанию в дженерик аргументах для `IPlainAction`, `IAction`. Они неочевидны и лишают возможности тайпчекеру помогать при опечатках. Даже в хелперах уже появились опечатки.
- Добавил более детальные типы для каждого экшена, чтобы тайпчекер также мог больше помогать. 
- Унифицировал некоторые имена.