### PR TITLE
Fix broken scss with thread loader

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
         "TS_NODE_FILES": true,
         "WATCH_MODE": true,
         "NODE_ENV": "development",
-        "TS_NODE_COMPILER_OPTIONS": "{\"target\": \"es6\", \"module\": \"commonjs\"}"
+        "TS_NODE_COMPILER_OPTIONS": "{\"target\": \"es6\", \"module\": \"commonjs\"}",
+        "ENABLE_THREAD_LOADER": false
       }
     },
     "server:dev:debug": {
@@ -50,7 +51,8 @@
         "TS_NODE_FILES": true,
         "WATCH_MODE": true,
         "NODE_ENV": "development",
-        "TS_NODE_COMPILER_OPTIONS": "{\"target\": \"es6\", \"module\": \"commonjs\"}"
+        "TS_NODE_COMPILER_OPTIONS": "{\"target\": \"es6\", \"module\": \"commonjs\"}",
+        "ENABLE_THREAD_LOADER": false
       }
     },
     "server:prod": {
@@ -59,7 +61,8 @@
         "PORT": 8080,
         "TS_NODE_FILES": true,
         "NODE_ENV": "production",
-        "TS_NODE_COMPILER_OPTIONS": "{\"target\": \"es5\", \"module\": \"commonjs\"}"
+        "TS_NODE_COMPILER_OPTIONS": "{\"target\": \"es5\", \"module\": \"commonjs\"}",
+        "ENABLE_THREAD_LOADER": true
       }
     },
     "server:prod:debug": {
@@ -68,7 +71,8 @@
         "PORT": 8080,
         "TS_NODE_FILES": true,
         "NODE_ENV": "production",
-        "TS_NODE_COMPILER_OPTIONS": "{\"target\": \"es5\", \"module\": \"commonjs\"}"
+        "TS_NODE_COMPILER_OPTIONS": "{\"target\": \"es5\", \"module\": \"commonjs\"}",
+        "ENABLE_THREAD_LOADER": true
       }
     },
     "watch:dev": {
@@ -77,7 +81,8 @@
         "NODE_ENV": "development",
         "TS_NODE_FILES": true,
         "WATCH_MODE": true,
-        "TS_NODE_COMPILER_OPTIONS": "{\"target\": \"es5\", \"module\": \"commonjs\"}"
+        "TS_NODE_COMPILER_OPTIONS": "{\"target\": \"es5\", \"module\": \"commonjs\"}",
+        "ENABLE_THREAD_LOADER": false
       }
     },
     "watch:prod": {
@@ -86,7 +91,8 @@
         "NODE_ENV": "production",
         "TS_NODE_FILES": true,
         "WATCH_MODE": true,
-        "TS_NODE_COMPILER_OPTIONS": "{\"target\": \"es5\", \"module\": \"commonjs\"}"
+        "TS_NODE_COMPILER_OPTIONS": "{\"target\": \"es5\", \"module\": \"commonjs\"}",
+        "ENABLE_THREAD_LOADER": false
       }
     },
     "analyze:dev": {
@@ -112,7 +118,8 @@
       "env": {
         "NODE_ENV": "development",
         "TS_NODE_FILES": true,
-        "TS_NODE_COMPILER_OPTIONS": "{\"target\": \"es5\", \"module\": \"commonjs\"}"
+        "TS_NODE_COMPILER_OPTIONS": "{\"target\": \"es5\", \"module\": \"commonjs\"}",
+        "ENABLE_THREAD_LOADER": false
       }
     },
     "build:prod": {
@@ -120,13 +127,15 @@
       "env": {
         "NODE_ENV": "production",
         "TS_NODE_FILES": true,
-        "TS_NODE_COMPILER_OPTIONS": "{\"target\": \"es5\", \"module\": \"commonjs\"}"
+        "TS_NODE_COMPILER_OPTIONS": "{\"target\": \"es5\", \"module\": \"commonjs\"}",
+        "ENABLE_THREAD_LOADER": false
       }
     },
     "build:gh-pages": {
       "command": "better-npm-run build:prod",
       "env": {
-        "NODE_ENV_MODE": "gh-pages"
+        "NODE_ENV_MODE": "gh-pages",
+        "ENABLE_THREAD_LOADER": false
       }
     },
     "deploy:gh-pages": {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
         "WATCH_MODE": true,
         "NODE_ENV": "development",
         "TS_NODE_COMPILER_OPTIONS": "{\"target\": \"es6\", \"module\": \"commonjs\"}",
-        "ENABLE_THREAD_LOADER": false
+        "THREADED": false
       }
     },
     "server:dev:debug": {
@@ -52,7 +52,7 @@
         "WATCH_MODE": true,
         "NODE_ENV": "development",
         "TS_NODE_COMPILER_OPTIONS": "{\"target\": \"es6\", \"module\": \"commonjs\"}",
-        "ENABLE_THREAD_LOADER": false
+        "THREADED": false
       }
     },
     "server:prod": {
@@ -62,7 +62,7 @@
         "TS_NODE_FILES": true,
         "NODE_ENV": "production",
         "TS_NODE_COMPILER_OPTIONS": "{\"target\": \"es5\", \"module\": \"commonjs\"}",
-        "ENABLE_THREAD_LOADER": true
+        "THREADED": true
       }
     },
     "server:prod:debug": {
@@ -72,7 +72,7 @@
         "TS_NODE_FILES": true,
         "NODE_ENV": "production",
         "TS_NODE_COMPILER_OPTIONS": "{\"target\": \"es5\", \"module\": \"commonjs\"}",
-        "ENABLE_THREAD_LOADER": true
+        "THREADED": true
       }
     },
     "watch:dev": {
@@ -82,7 +82,7 @@
         "TS_NODE_FILES": true,
         "WATCH_MODE": true,
         "TS_NODE_COMPILER_OPTIONS": "{\"target\": \"es5\", \"module\": \"commonjs\"}",
-        "ENABLE_THREAD_LOADER": false
+        "THREADED": false
       }
     },
     "watch:prod": {
@@ -92,7 +92,7 @@
         "TS_NODE_FILES": true,
         "WATCH_MODE": true,
         "TS_NODE_COMPILER_OPTIONS": "{\"target\": \"es5\", \"module\": \"commonjs\"}",
-        "ENABLE_THREAD_LOADER": false
+        "THREADED": false
       }
     },
     "analyze:dev": {
@@ -119,7 +119,7 @@
         "NODE_ENV": "development",
         "TS_NODE_FILES": true,
         "TS_NODE_COMPILER_OPTIONS": "{\"target\": \"es5\", \"module\": \"commonjs\"}",
-        "ENABLE_THREAD_LOADER": false
+        "THREADED": false
       }
     },
     "build:prod": {
@@ -128,14 +128,14 @@
         "NODE_ENV": "production",
         "TS_NODE_FILES": true,
         "TS_NODE_COMPILER_OPTIONS": "{\"target\": \"es5\", \"module\": \"commonjs\"}",
-        "ENABLE_THREAD_LOADER": false
+        "THREADED": false
       }
     },
     "build:gh-pages": {
       "command": "better-npm-run build:prod",
       "env": {
         "NODE_ENV_MODE": "gh-pages",
-        "ENABLE_THREAD_LOADER": false
+        "THREADED": false
       }
     },
     "deploy:gh-pages": {

--- a/webpack/common.ts
+++ b/webpack/common.ts
@@ -23,7 +23,7 @@ export type BuildType = 'dev' | 'prod' | 'server';
 const { chunkHash, withAnalyze, chunkName, withHot } = getEnvParams();
 
 const threadLoader: webpack.Loader[] = (() => {
-  if (process.env.ENABLE_THREAD_LOADER) {
+  if (process.env.THREADED) {
     const workerPool = {
       workers: require('os').cpus().length - 1,
       poolTimeout: withHot ? Infinity : 2000,

--- a/webpack/common.ts
+++ b/webpack/common.ts
@@ -6,7 +6,7 @@ import * as MiniCssExtractPlugin from 'mini-css-extract-plugin';
 import * as CircularDependencyPlugin from 'circular-dependency-plugin';
 import { BundleAnalyzerPlugin } from 'webpack-bundle-analyzer';
 import * as ForkTsCheckerWebpackPlugin from 'fork-ts-checker-webpack-plugin';
-import * as threadLoader from 'thread-loader';
+import * as threadLoaderLib from 'thread-loader';
 import * as FaviconsWebpackPlugin from 'favicons-webpack-plugin';
 
 import * as postcssReporter from 'postcss-reporter';
@@ -27,12 +27,17 @@ const workerPool = {
   poolTimeout: withHot ? Infinity : 2000,
 };
 
-threadLoader.warmup(workerPool, [
+threadLoaderLib.warmup(workerPool, [
   'babel-loader',
   'ts-loader',
   'postcss-loader',
   'sass-loader',
 ]);
+
+const threadLoader: webpack.Loader = {
+  loader: 'thread-loader',
+  options: workerPool,
+};
 
 export const getCommonPlugins: (type: BuildType) => webpack.Plugin[] = (type) => [
   new CleanWebpackPlugin(['build', 'static'], { root: path.resolve(__dirname, '..') }),
@@ -84,11 +89,8 @@ function sortChunks(a: webpack.compilation.Chunk, b: webpack.compilation.Chunk) 
 export const getCommonRules: (type: BuildType) => webpack.Rule[] = (type) => [
   {
     test: /\.tsx?$/,
-    use: ([
-      {
-        loader: 'thread-loader',
-        options: workerPool,
-      }] as webpack.Loader[])
+    use:
+      [threadLoader]
       .concat(withHot && type === 'dev' ? {
         loader: 'babel-loader',
         options: {
@@ -128,6 +130,7 @@ export function getStyleRules(type: BuildType) {
     prod: [MiniCssExtractPlugin.loader, 'css-loader'],
     server: ['css-loader/locals'],
   };
+
   const scssFirstLoaders: Record<BuildType, webpack.Loader[]> = {
     dev: ['style-loader', 'css-loader?importLoaders=1'],
     prod: [MiniCssExtractPlugin.loader, 'css-loader?importLoaders=1'],
@@ -141,16 +144,12 @@ export function getStyleRules(type: BuildType) {
     },
     {
       test: /\.scss$/,
-      use: (scssFirstLoaders[type]).concat(commonScssLoaders),
+      use: [threadLoader].concat(scssFirstLoaders[type]).concat(commonScssLoaders),
     },
   ];
 }
 
 const commonScssLoaders: webpack.Loader[] = [
-  {
-    loader: 'thread-loader',
-    options: workerPool,
-  },
   {
     loader: 'postcss-loader',
     options: {

--- a/webpack/common.ts
+++ b/webpack/common.ts
@@ -23,7 +23,7 @@ export type BuildType = 'dev' | 'prod' | 'server';
 const { chunkHash, withAnalyze, chunkName, withHot } = getEnvParams();
 
 const threadLoader: webpack.Loader[] = (() => {
-  if (process.env.THREADED) {
+  if (process.env.THREADED === 'true') {
     const workerPool = {
       workers: require('os').cpus().length - 1,
       poolTimeout: withHot ? Infinity : 2000,


### PR DESCRIPTION
[Этот коммит](https://github.com/fullstack-development/react-redux-starter-kit/commit/795069ef0da0bd0afcd708ecc8bd0e0b9a6bb3af#diff-2ce1fb76f5dd5d08de37f636dbd0c872) сломал SCSS. 
1) Пофикшен сломанный SCSS.
2) Добавлена env переменная для того, чтобы вообще тред лоадер дизейблить (задизейблен по дефолту везде кроме сервер:прод скриптов). Зачем: по предложению Никиты (типа с ним возникают пробемы периодически, да и вообще с ним может хуже работать, чем без него).