### PR TITLE
Add esModuleInterop flag to TSconfig

### DIFF
--- a/@types/react-jss/index.d.ts
+++ b/@types/react-jss/index.d.ts
@@ -1,5 +1,5 @@
 declare module 'react-jss' {
-  import * as React from 'react';
+  import React from 'react';
   import { create, GenerateClassName } from 'jss';
 
   export { default as withTheme, Theme, WithTheme } from 'theming';
@@ -20,5 +20,3 @@ declare module 'react-jss' {
     public toString(): string;
   }
 }
-
-

--- a/@types/react-jss/lib/injectSheet.d.ts
+++ b/@types/react-jss/lib/injectSheet.d.ts
@@ -1,7 +1,7 @@
 
 declare module 'react-jss/lib/injectSheet' {
-  import * as React from 'react';
-  import * as CSS from 'csstype';
+  import React from 'react';
+  import CSS from 'csstype';
   import { WithTheme, Theme } from 'theming';
   import { ConsistentWith, Overwrite } from '_helpers';
 

--- a/docs/ru/feature/lazy-feature.md
+++ b/docs/ru/feature/lazy-feature.md
@@ -46,7 +46,7 @@ export { loadEntry } from './loader';
 С помощью HOC'а `featureConnect` можно упростить процесс получения данных фичи и подключения фичи к redux-стору. Использовать его можно только в модулях. На вход принимает мап-объект с лоадерами интересующих нас фич и react-компонент, ключи этого объекта должны совпадать с ключами пропсов оборачиваемого react-компонента. После успешной загрузки фич они будут автоматически подключены к redux-стору и объекты с данными фич будут прокинуты в оборачиваемый react-компонент. Также ему можно передать прелоадер, который будет отображаться во время загрузки фич.
 
 ```typescript
-import * as React from 'react';
+import React from 'react';
 import { featureConnect } from 'core';
 
 import { RouteComponentProps } from 'react-router-dom';
@@ -107,7 +107,7 @@ export { IContainerTypes };
 Пример использования:
 
 ```typescript
-import * as React from 'react';
+import React from 'react';
 import { IContainerTypes, containersProvider } from 'core';
 
 interface IProps {

--- a/docs/ru/styling.md
+++ b/docs/ru/styling.md
@@ -46,7 +46,7 @@ export type StylesProps = WithStyles<typeof styles>;
 
 Файл `MyComponent.tsx`:
 ```typescript
-import * as React from 'react';
+import React from 'react';
 import { provideStyles, StylesProps } from './MyComponent.style';
 
 interface IProps {

--- a/generators/app/templates/view/components/SomeComponent/SomeComponent.tsx
+++ b/generators/app/templates/view/components/SomeComponent/SomeComponent.tsx
@@ -1,11 +1,11 @@
-import * as React from 'react';
+import React from 'react';
 import * as block from 'bem-cn';
 import { bind } from 'decko';
 
 import './SomeComponent.scss';
 
 interface IProps {
-  
+
 }
 
 const b = block('block-name');

--- a/generators/app/templates/view/containers/SomeContainer/SomeContainer.tsx
+++ b/generators/app/templates/view/containers/SomeContainer/SomeContainer.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import * as block from 'bem-cn';
 import { bind } from 'decko';
 import { connect } from 'react-redux';
@@ -12,15 +12,15 @@ import { actions, selectors } from './../../../redux';
 import './SomeContainer.scss';
 
 interface IOwnProps {
-  
+
 }
 
 interface IStateProps {
-  
+
 }
 
 interface IActionProps {
-  
+
 }
 
 type IProps = IStateProps & IActionProps & IOwnProps;

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,4 +1,4 @@
-import * as Enzyme from 'enzyme';
-import * as Adapter from 'enzyme-adapter-react-16';
+import Enzyme from 'enzyme';
+import Adapter from 'enzyme-adapter-react-16';
 
 Enzyme.configure({ adapter: new (Adapter as any)() });

--- a/server/index.ts
+++ b/server/index.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import * as express from 'express';
+import express from 'express';
 import clientConfig from '../webpack/isomorphic/client.config';
 import serverConfig from '../webpack/isomorphic/server.config';
 import { startDevelopmentMode, startProductionMode } from './starters';

--- a/server/middleware.ts
+++ b/server/middleware.ts
@@ -1,7 +1,7 @@
-import * as cookieParser from 'cookie-parser';
-import * as compression from 'compression';
-import * as express from 'express';
-import * as path from 'path';
+import cookieParser from 'cookie-parser';
+import compression from 'compression';
+import express from 'express';
+import path from 'path';
 
 export default function middleware(app: express.Express) {
   app.use(compression());

--- a/server/starters.ts
+++ b/server/starters.ts
@@ -1,8 +1,8 @@
-import * as webpack from 'webpack';
+import webpack from 'webpack';
 import { Express } from 'express';
-import * as hotMiddleware from 'webpack-hot-middleware';
-import * as SSRMiddleware from 'webpack-isomorphic-dev-middleware';
-import * as $ from 'cheerio';
+import hotMiddleware from 'webpack-hot-middleware';
+import SSRMiddleware from 'webpack-isomorphic-dev-middleware';
+import $ from 'cheerio';
 
 import { IAssets } from '../src/shared/types/app';
 

--- a/src/assets/Html.tsx
+++ b/src/assets/Html.tsx
@@ -1,7 +1,7 @@
-import * as React from 'react';
-import * as serialize from 'serialize-javascript';
+import React from 'react';
+import serialize from 'serialize-javascript';
 import Helmet from 'react-helmet';
-import * as redux from 'redux';
+import redux from 'redux';
 import { renderToString } from 'react-dom/server';
 
 import { IAssets } from 'shared/types/app';

--- a/src/client.tsx
+++ b/src/client.tsx
@@ -1,9 +1,9 @@
 import 'reflect-metadata';
 import 'babel-polyfill';
 import { App } from 'core/App';
-import * as React from 'react';
-import * as ReactDOM from 'react-dom';
-import * as bootstrapper from 'react-async-bootstrapper';
+import React from 'react';
+import ReactDOM from 'react-dom';
+import bootstrapper from 'react-async-bootstrapper';
 import configureApp from 'core/configureApp';
 
 import getEnvParams from './core/getEnvParams';

--- a/src/core/App.tsx
+++ b/src/core/App.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import { Provider } from 'react-redux';
 import { BrowserRouter, StaticRouter } from 'react-router-dom';
 import 'normalize.css';

--- a/src/core/ContainersProvider.tsx
+++ b/src/core/ContainersProvider.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import { bind } from 'decko';
 import { Omit } from '_helpers';
 

--- a/src/core/FeatureConnector.tsx
+++ b/src/core/FeatureConnector.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import { bind } from 'decko';
 import * as R from 'ramda';
 import { injectable } from 'inversify';

--- a/src/core/routes.tsx
+++ b/src/core/routes.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import { Route, RouteComponentProps, Redirect, Switch } from 'react-router-dom';
 
 import { App } from 'modules/App';

--- a/src/modules/App/view/App.tsx
+++ b/src/modules/App/view/App.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 
 class App extends React.Component {
   public render() {

--- a/src/modules/Demo/Demo.tsx
+++ b/src/modules/Demo/Demo.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import { Route, Switch, Redirect } from 'react-router-dom';
 
 import routes from 'modules/routes';

--- a/src/modules/Demo/view/DemoGUI/DemoGUI.tsx
+++ b/src/modules/Demo/view/DemoGUI/DemoGUI.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import { Form, FormRenderProps } from 'react-final-form';
 
 import { Button, Typography, CircleProgressBar, Grid } from 'shared/view/elements';

--- a/src/modules/Demo/view/DemoGUI/components/Checkboxes/Checkboxes.tsx
+++ b/src/modules/Demo/view/DemoGUI/components/Checkboxes/Checkboxes.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 
 import { Typography, Grid } from 'shared/view/elements';
 import { CheckboxInputField } from 'shared/view/form';

--- a/src/modules/Demo/view/DemoGUI/components/RadioGroups/RadioGroups.tsx
+++ b/src/modules/Demo/view/DemoGUI/components/RadioGroups/RadioGroups.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 
 import { Typography, FormControlLabel, Radio, Grid } from 'shared/view/elements';
 import { RadioGroupInputField } from 'shared/view/form';

--- a/src/modules/Demo/view/DemoGUI/components/TextInputs/TextInputs.tsx
+++ b/src/modules/Demo/view/DemoGUI/components/TextInputs/TextInputs.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 
 import { Typography, MenuItem, Grid } from 'shared/view/elements';
 import { TextInputField, MaskedInputField, NumberInputField } from 'shared/view/form';

--- a/src/modules/Demo/view/DemoTranslations/DemoTranslations.tsx
+++ b/src/modules/Demo/view/DemoTranslations/DemoTranslations.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 
 import { withI18n, ITranslateProps, tKeys, LanguageSelector } from 'services/i18n';
 

--- a/src/modules/shared/BaseLayout/BaseLayout.tsx
+++ b/src/modules/shared/BaseLayout/BaseLayout.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import { withRouter, RouteComponentProps } from 'react-router';
 
 import { RowsLayout } from 'shared/view/elements';

--- a/src/server.tsx
+++ b/src/server.tsx
@@ -1,7 +1,7 @@
 import 'reflect-metadata';
-import * as express from 'express';
-import * as React from 'react';
-import * as bootstrapper from 'react-async-bootstrapper';
+import express from 'express';
+import React from 'react';
+import bootstrapper from 'react-async-bootstrapper';
 import { renderToString } from 'react-dom/server';
 
 import { IAssets, IAppData } from 'shared/types/app';

--- a/src/services/i18n/constants.ts
+++ b/src/services/i18n/constants.ts
@@ -1,5 +1,5 @@
-import * as React from 'react';
-import * as Polyglot from 'node-polyglot';
+import React from 'react';
+import Polyglot from 'node-polyglot';
 
 import buildTranslationKeys from './helpers/buildTranslationKeys';
 

--- a/src/services/i18n/namespace.ts
+++ b/src/services/i18n/namespace.ts
@@ -1,4 +1,4 @@
-import * as Polyglot from 'node-polyglot';
+import Polyglot from 'node-polyglot';
 
 type CustomTranslateFunction = (phrase: IPhraseWithOptions) => string;
 interface IPhraseWithOptions {

--- a/src/services/i18n/view/I18nProvider/I18nProvider.tsx
+++ b/src/services/i18n/view/I18nProvider/I18nProvider.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 import { bind } from 'decko';
-import * as Polyglot from 'node-polyglot';
+import Polyglot from 'node-polyglot';
 
 import { withProps } from 'shared/helpers/react';
 

--- a/src/services/i18n/view/LanguageSelector/LanguageSelector.tsx
+++ b/src/services/i18n/view/LanguageSelector/LanguageSelector.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import { bind } from 'decko';
 
 import { Lang, ITranslateProps } from '../../namespace';

--- a/src/services/i18n/view/withI18n/withI18n.tsx
+++ b/src/services/i18n/view/withI18n/withI18n.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import { Omit } from '_helpers';
 
 import { ITranslateProps } from '../../namespace';

--- a/src/services/theme/view/containers/ThemeProvider/ThemeProvider.tsx
+++ b/src/services/theme/view/containers/ThemeProvider/ThemeProvider.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import { connect } from 'react-redux';
 import { withRouter, RouteComponentProps } from 'react-router';
 import MuiThemeProvider from '@material-ui/core/styles/MuiThemeProvider';

--- a/src/services/theme/view/containers/ThemeSelector/ThemeSelector.tsx
+++ b/src/services/theme/view/containers/ThemeSelector/ThemeSelector.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import { connect } from 'react-redux';
 import { bind } from 'decko';
 

--- a/src/shared/helpers/react/getFieldWithComponent.tsx
+++ b/src/shared/helpers/react/getFieldWithComponent.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import { Field, FieldRenderProps, FieldProps as RFFieldProps } from 'react-final-form';
 import { Omit, MergeRight } from '_helpers';
 

--- a/src/shared/helpers/react/withProps.tsx
+++ b/src/shared/helpers/react/withProps.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import { Omit } from '_helpers';
 
 function withProps<P extends Partial<WP>, WP extends {}>(

--- a/src/shared/helpers/withComponent.tsx
+++ b/src/shared/helpers/withComponent.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import { Omit } from 'react-redux';
 import { GetProps } from '_helpers';
 

--- a/src/shared/styles/BaseStyles.tsx
+++ b/src/shared/styles/BaseStyles.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import { rule } from 'shared/helpers/style';
 import { withStyles, WithStyles } from './jss';
 

--- a/src/shared/view/components/Footer/Footer.tsx
+++ b/src/shared/view/components/Footer/Footer.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import AppBar from '@material-ui/core/AppBar';
 import Toolbar from '@material-ui/core/Toolbar';
 import Typography from '@material-ui/core/Typography';

--- a/src/shared/view/components/Header/Header.tsx
+++ b/src/shared/view/components/Header/Header.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import AppBar from '@material-ui/core/AppBar';
 import Toolbar from '@material-ui/core/Toolbar';
 

--- a/src/shared/view/elements/CheckboxInput/CheckboxInput.tsx
+++ b/src/shared/view/elements/CheckboxInput/CheckboxInput.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import { CheckIdentity } from '_helpers';
 import FormControl, { FormControlProps } from '@material-ui/core/FormControl';
 import FormHelperText, { FormHelperTextProps } from '@material-ui/core/FormHelperText';

--- a/src/shared/view/elements/CircleProgressBar/CircleProgressBar.tsx
+++ b/src/shared/view/elements/CircleProgressBar/CircleProgressBar.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import CircularProgress, { CircularProgressProps } from '@material-ui/core/CircularProgress';
 
 import { StylesProps, provideStyles } from './CircleProgressBar.style';

--- a/src/shared/view/elements/Input/MaskedInput.tsx
+++ b/src/shared/view/elements/Input/MaskedInput.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import * as R from 'ramda';
 import { GetProps } from '_helpers';
 import ReactTextMask from 'react-text-mask';

--- a/src/shared/view/elements/Input/NumberInput.tsx
+++ b/src/shared/view/elements/Input/NumberInput.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import * as R from 'ramda';
 import { MergeRight } from '_helpers';
 import NumberFormat, { NumberFormatProps, NumberFormatValues } from 'react-number-format';

--- a/src/shared/view/elements/Input/TextInput.tsx
+++ b/src/shared/view/elements/Input/TextInput.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import { bind } from 'decko';
 import { MarkAsPartial, SubSet } from '_helpers';
 

--- a/src/shared/view/elements/RadioGroupInput/RadioGroupInput.tsx
+++ b/src/shared/view/elements/RadioGroupInput/RadioGroupInput.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import { CheckIdentity } from '_helpers';
 import FormControl, { FormControlProps } from '@material-ui/core/FormControl';
 import FormLabel, { FormLabelProps } from '@material-ui/core/FormLabel';

--- a/src/shared/view/elements/RowsLayout/RowsLayout.tsx
+++ b/src/shared/view/elements/RowsLayout/RowsLayout.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import { provideStyles, StylesProps } from './RowsLayout.style';
 import Grid from '@material-ui/core/Grid/Grid';
 

--- a/src/shared/view/elements/Tooltip/Tooltip.tsx
+++ b/src/shared/view/elements/Tooltip/Tooltip.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import MuiTooltip, { TooltipProps } from '@material-ui/core/Tooltip';
 
 import { StylesProps, provideStyles } from './Tooltip.styles';

--- a/src/shared/view/form/CheckboxInputField/CheckboxInputField.tsx
+++ b/src/shared/view/form/CheckboxInputField/CheckboxInputField.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import { FieldRenderProps } from 'react-final-form';
 import { GetProps } from '_helpers';
 

--- a/src/shared/view/form/MaskedInputField/MaskedInputField.tsx
+++ b/src/shared/view/form/MaskedInputField/MaskedInputField.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import { FieldRenderProps } from 'react-final-form';
 import { GetProps } from '_helpers';
 

--- a/src/shared/view/form/NumberInputField/NumberInputField.tsx
+++ b/src/shared/view/form/NumberInputField/NumberInputField.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import { FieldRenderProps } from 'react-final-form';
 import { GetProps } from '_helpers';
 

--- a/src/shared/view/form/RadioGroupInputField/RadioGroupInputField.tsx
+++ b/src/shared/view/form/RadioGroupInputField/RadioGroupInputField.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import { FieldRenderProps } from 'react-final-form';
 import { GetProps } from '_helpers';
 

--- a/src/shared/view/form/TextInputField/TextInputField.tsx
+++ b/src/shared/view/form/TextInputField/TextInputField.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import { FieldRenderProps } from 'react-final-form';
 import { GetProps } from '_helpers';
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -27,7 +27,8 @@
     "strictFunctionTypes": false,
     "strictBindCallApply": true,
     "sourceMap": true,
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    "esModuleInterop": true,
   },
   "include": [
     "src/**/*",

--- a/webpack/common.ts
+++ b/webpack/common.ts
@@ -1,20 +1,20 @@
-import * as path from 'path';
-import * as webpack from 'webpack';
-import * as HtmlWebpackPlugin from 'html-webpack-plugin';
-import * as CleanWebpackPlugin from 'clean-webpack-plugin';
-import * as MiniCssExtractPlugin from 'mini-css-extract-plugin';
-import * as CircularDependencyPlugin from 'circular-dependency-plugin';
+import path from 'path';
+import webpack from 'webpack';
+import HtmlWebpackPlugin from 'html-webpack-plugin';
+import CleanWebpackPlugin from 'clean-webpack-plugin';
+import MiniCssExtractPlugin from 'mini-css-extract-plugin';
+import CircularDependencyPlugin from 'circular-dependency-plugin';
 import { BundleAnalyzerPlugin } from 'webpack-bundle-analyzer';
-import * as ForkTsCheckerWebpackPlugin from 'fork-ts-checker-webpack-plugin';
-import * as threadLoaderLib from 'thread-loader';
-import * as FaviconsWebpackPlugin from 'favicons-webpack-plugin';
+import ForkTsCheckerWebpackPlugin from 'fork-ts-checker-webpack-plugin';
+import threadLoaderLib from 'thread-loader';
+import FaviconsWebpackPlugin from 'favicons-webpack-plugin';
 
-import * as postcssReporter from 'postcss-reporter';
-import * as postcssEasyImport from 'postcss-easy-import';
-import * as postcssSCSS from 'postcss-scss';
-import * as autoprefixer from 'autoprefixer';
-import * as stylelint from 'stylelint';
-import * as doiuse from 'doiuse';
+import postcssReporter from 'postcss-reporter';
+import postcssEasyImport from 'postcss-easy-import';
+import postcssSCSS from 'postcss-scss';
+import autoprefixer from 'autoprefixer';
+import stylelint from 'stylelint';
+import doiuse from 'doiuse';
 
 import getEnvParams from '../src/core/getEnvParams';
 

--- a/webpack/dev.config.ts
+++ b/webpack/dev.config.ts
@@ -1,4 +1,4 @@
-import * as webpack from 'webpack';
+import webpack from 'webpack';
 
 import { getCommonRules, commonConfig, getStyleRules, BuildType, getCommonPlugins } from './common';
 

--- a/webpack/isomorphic/client.config.ts
+++ b/webpack/isomorphic/client.config.ts
@@ -1,5 +1,5 @@
-import * as path from 'path';
-import * as webpack from 'webpack';
+import path from 'path';
+import webpack from 'webpack';
 import getDevConfig from '../dev.config';
 import getProdConfig from '../prod.config';
 

--- a/webpack/isomorphic/server.config.ts
+++ b/webpack/isomorphic/server.config.ts
@@ -1,6 +1,6 @@
-import * as path from 'path';
-import * as webpack from 'webpack';
-import * as nodeExternals from 'webpack-node-externals';
+import path from 'path';
+import webpack from 'webpack';
+import nodeExternals from 'webpack-node-externals';
 
 import getDevConfig from '../dev.config';
 import getProdConfig from '../prod.config';

--- a/webpack/prod.config.ts
+++ b/webpack/prod.config.ts
@@ -1,4 +1,4 @@
-import * as webpack from 'webpack';
+import webpack from 'webpack';
 
 import { getCommonPlugins, getCommonRules, commonConfig, getStyleRules, BuildType } from './common';
 


### PR DESCRIPTION
Добавил флаг, который позволяет юзать дефолтный импорт без дефолтного экспорта для non-ES модулей, вместо того, чтобы писать `import * as `

[здесь](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-7.html) внизу про это написано
