### PR TITLE
100 repo search preloader

### DIFF
--- a/src/features/repositoriesSearch/view/containers/RepositoriesSearchResults/RepositoriesSearchResults.scss
+++ b/src/features/repositoriesSearch/view/containers/RepositoriesSearchResults/RepositoriesSearchResults.scss
@@ -1,4 +1,8 @@
 .repositories-search-results {
+  &__repositories {
+    position: relative;
+  }
+
   &__repository-preview {
     border-top: 1px solid #cfcfcf;
 

--- a/src/features/repositoriesSearch/view/containers/RepositoriesSearchResults/RepositoriesSearchResults.tsx
+++ b/src/features/repositoriesSearch/view/containers/RepositoriesSearchResults/RepositoriesSearchResults.tsx
@@ -8,7 +8,7 @@ import { IAppReduxState } from 'shared/types/app';
 import { IRepository } from 'shared/types/models';
 import { IPaginationState } from 'shared/types/common';
 import { PaginationControls } from 'shared/view/components';
-import { TotalSearchResults } from 'shared/view/elements';
+import { TotalSearchResults, Preloader } from 'shared/view/elements';
 
 import { IRepositoriesSearchFormFields } from '../../../namespace';
 import { actions, selectors } from './../../../redux';
@@ -27,6 +27,7 @@ interface IStateProps {
   repositories: IRepository[];
   paginationState: IPaginationState;
   totalResults: number;
+  isSearchRequesting: boolean;
 }
 
 type IActionProps = typeof mapDispatch;
@@ -42,6 +43,7 @@ function mapState(state: IAppReduxState): IStateProps {
     repositories: selectors.selectFoundRepositories(state),
     paginationState: selectors.selectRepositoriesSearchPaginationState(state),
     totalResults: selectors.selectTotalResults(state),
+    isSearchRequesting: selectors.selectCommunication(state, 'searchRepositories').isRequesting,
   };
 }
 
@@ -57,12 +59,18 @@ class RepositoriesSearchResults extends React.PureComponent<IProps> {
   };
 
   public render() {
-    const { repositories, UserDetails, paginationState: { totalPages, page }, totalResults } = this.props;
+    const {
+      repositories, UserDetails, paginationState: { totalPages, page },
+      totalResults, isSearchRequesting,
+    } = this.props;
     const { displayedRepositoryOwner } = this.state;
     return (
       <div className={b()}>
         <TotalSearchResults totalResults={totalResults} />
-        {repositories.map(this.renderRepositoryPreview)}
+        <div className={b('repositories')}>
+          <Preloader size={0} backgroundColor="rgba(0, 0, 0, 0.05)" isShown={isSearchRequesting} />
+          {repositories.map(this.renderRepositoryPreview)}
+        </div>
         <div className={b('pagination')}>
           <PaginationControls
             totalPages={totalPages}

--- a/src/features/repositoriesSearch/view/containers/RepositoriesSearchResults/__tests__/index.test.ts
+++ b/src/features/repositoriesSearch/view/containers/RepositoriesSearchResults/__tests__/index.test.ts
@@ -1,6 +1,7 @@
 import { makeShallowRenderer } from 'shared/helpers';
 import { makeMockComponent, repository } from 'shared/mocks';
 import { PaginationControls } from 'shared/view/components';
+import { Preloader } from 'shared/view/elements';
 
 import { RepositoryPreview } from '../../../components';
 import {
@@ -19,6 +20,7 @@ const props: IRepositoriesSearchResultsProps = {
   searchRepositories: jest.fn(),
   UserDetails: makeMockComponent('UserDetails'),
   totalResults: 1,
+  isSearchRequesting: false,
 };
 
 const getComponent = makeShallowRenderer(RepositoriesSearchResults, props);
@@ -57,5 +59,13 @@ describe('(features/repositoriesSearch) RepositoriesSearchResults container', ()
 
     component.find(UserDetails).prop('onClose')();
     expect(component.find(UserDetails).length).toBe(0);
+  });
+
+  it('should show preloader if search is requesting', () => {
+    const component = getComponent({ isSearchRequesting: false });
+    expect(component.find(Preloader).prop('isShown')).toBe(false);
+
+    const componentRequesting = getComponent({ isSearchRequesting: true });
+    expect(componentRequesting.find(Preloader).prop('isShown')).toBe(true);
   });
 });

--- a/src/features/usersSearch/view/containers/UserDetails/UserDetails.tsx
+++ b/src/features/usersSearch/view/containers/UserDetails/UserDetails.tsx
@@ -77,7 +77,7 @@ class UserDetails extends React.Component<IProps> {
               src={injectSizeToAvatarURL(avatarURL, this.avatarSize)}
             />
             <Typography variant="h5">{realName}</Typography>
-            <Typography variant="subtitle1">{username}</Typography>
+            <Typography variant="subtitle1" noWrap>{username}</Typography>
             {location && <Typography variant="subtitle2" color="textSecondary">{location}</Typography>}
           </a>
           <div className={b('attributes')}>

--- a/src/modules/Search/view/components/RepositoriesSearchLayout/RepositoriesSearchLayout.scss
+++ b/src/modules/Search/view/components/RepositoriesSearchLayout/RepositoriesSearchLayout.scss
@@ -15,7 +15,7 @@
     width: 100%;
 
     @include breakpoint-up(sm) {
-      width: 32rem;
+      width: 34rem;
     }
   }
 }


### PR DESCRIPTION
Проблема: когда летит запрос на поиск (по сабмиту формы поиска кнопкой или при тыке на пагинацию), блочится форма поиска, таким образом юзер видит, что "поиск пошел". Но в поиске реп, из-за того что список резалтов длинный, пагинация находится в самом низу страницы, если на неё тыкнуть, то до того, как прилетят результаты и произойдет перерендер, интерфейс как будто бы "тупит" и никак не реагирует (потому что форма находится где-то там вверху и юзер ее не видит). С точки зрения юзера это не приятно: не понятно вообще как-то приложение на тебя отреагировало или нет. 

Добавил такую вот "дизейблящую херню", пока запрос летит
![image](https://user-images.githubusercontent.com/18498637/55699786-ad8c7100-59f6-11e9-9b98-b3fcc76efb96.png)

