### PR TITLE
Исправление ошибки Unexpected Keys в SSR режиме

### DIFF
--- a/src/core/configureApp.ts
+++ b/src/core/configureApp.ts
@@ -4,11 +4,17 @@ import configureStore, { createReducer } from './configureStore';
 import { configureJss } from './configureJss';
 
 import * as allModules from 'modules';
-import { ReducersMap } from 'shared/types/redux';
+
 import { reduxEntry as themeProviderRE } from 'services/theme';
 import { reduxEntry as notificationReduxEntry } from 'services/notification';
-import { IAppData, IModule, RootSaga, IAppReduxState, IReduxEntry } from 'shared/types/app';
 import { initializeI18n } from 'services/i18n/i18nContainer';
+
+import { reduxEntry as profileReduxEntry } from 'features/profile/entry';
+import { reduxEntry as repositoriesSearchReduxEntry } from 'features/repositoriesSearch/entry';
+import { reduxEntry as usersSearchReduxEntry } from 'features/usersSearch/entry';
+
+import { ReducersMap } from 'shared/types/redux';
+import { IAppData, IModule, RootSaga, IAppReduxState, IReduxEntry } from 'shared/types/app';
 
 function configureApp(data?: IAppData): IAppData {
   /* Prepare main app elements */
@@ -21,6 +27,9 @@ function configureApp(data?: IAppData): IAppData {
   const sharedReduxEntries: IReduxEntry[] = [
     themeProviderRE,
     notificationReduxEntry,
+    profileReduxEntry,
+    repositoriesSearchReduxEntry,
+    usersSearchReduxEntry,
   ];
 
   const connectedSagas: RootSaga[] = [];
@@ -46,6 +55,10 @@ function configureApp(data?: IAppData): IAppData {
       connectEntryToStore(module.getReduxEntry());
     }
   });
+
+  const isBrowser = typeof window !== 'undefined';
+  const initial: IAppReduxState | undefined = isBrowser ? window.__data : undefined;
+  isBrowser && store.dispatch({ type: 'RESET_STATE', payload: initial });
 
   function connectEntryToStore({ reducers, sagas }: IReduxEntry) {
     if (!store) {

--- a/src/features/profile/entry.ts
+++ b/src/features/profile/entry.ts
@@ -1,15 +1,19 @@
 import makeFeatureEntry from 'shared/helpers/makeFeatureEntry';
 
+import { IReduxEntry } from 'shared/types/app';
+
 import { actions, selectors, reducer } from './redux';
 import * as containers from './view/containers';
+
+export const reduxEntry: IReduxEntry = {
+  reducers: { profile: reducer },
+};
 
 const entry = makeFeatureEntry({
   containers,
   actions,
   selectors,
-  reduxEntry: {
-    reducers: { profile: reducer },
-  },
+  reduxEntry,
 });
 
 type Entry = typeof entry;

--- a/src/features/repositoriesSearch/entry.ts
+++ b/src/features/repositoriesSearch/entry.ts
@@ -1,16 +1,20 @@
 import makeFeatureEntry from 'shared/helpers/makeFeatureEntry';
 
+import { IReduxEntry } from 'shared/types/app';
+
 import { actions, selectors, reducer, getSaga } from './redux';
 import * as containers from './view/containers';
+
+export const reduxEntry: IReduxEntry = {
+  reducers: { repositoriesSearch: reducer },
+  sagas: [getSaga],
+};
 
 const entry = makeFeatureEntry({
   containers,
   actions,
   selectors,
-  reduxEntry: {
-    reducers: { repositoriesSearch: reducer },
-    sagas: [getSaga],
-  },
+  reduxEntry,
 });
 
 type Entry = typeof entry;

--- a/src/features/usersSearch/entry.ts
+++ b/src/features/usersSearch/entry.ts
@@ -1,16 +1,20 @@
 import makeFeatureEntry from 'shared/helpers/makeFeatureEntry';
 
+import { IReduxEntry } from 'shared/types/app';
+
 import { actions, selectors, reducer, getSaga } from './redux';
 import * as containers from './view/containers';
+
+export const reduxEntry: IReduxEntry = {
+  reducers: { usersSearch: reducer },
+  sagas: [getSaga],
+};
 
 const entry = makeFeatureEntry({
   containers,
   actions,
   selectors,
-  reduxEntry: {
-    reducers: { usersSearch: reducer },
-    sagas: [getSaga],
-  },
+  reduxEntry,
 });
 
 type Entry = typeof entry;


### PR DESCRIPTION
Сегодня на одном из проектов столкнулись с проблемой: при запуске ssr сыпались ошибки вида: 

> Unexpected keys "one", "two" found in initialState argument passed to createStore. Expected to find one of the known reducer keys instead: "events", "flash". Unexpected keys will be ignored.

Где "one", "two", "events", "flash" — имена фич.

И мы пофиксили эту проблему так же, как на другом проекте. Поэтому я подумал перенести это решение в стартер кит. Однако, после переноса иницилазции стейта после создания редюсеров, страница через сср перестала запускаться, т.к. некоторые стейты фич оказались undefined. Тогда я решил подцепить редаксы этих фич прямо в configureApp, как мы это делаем на других проектах. Из всего этого мне непонятно одно — почему тогда фичи работали раньше?)

P.S. Кстати, в SSR режиме у страницы нет стилей