### PR TITLE
fix ssr dev starter (#171)

### DIFF
--- a/server/starters.ts
+++ b/server/starters.ts
@@ -21,7 +21,7 @@ function startDevelopmentMode(
     // res.isomorphic contains `compilation` & `exports` properties:
     // - `compilation` contains the webpack-isomorphic-compiler compilation result
     // - `exports` contains the server exports, usually one or more render functions
-    const { compilation, exports: { default: render } } = res.locals.isomorphic;
+    const { compilation, exports: { render } } = res.locals.isomorphic;
     const { clientStats } = compilation;
 
     const assets = extractAssets(clientStats.compilation);

--- a/src/server.tsx
+++ b/src/server.tsx
@@ -80,4 +80,5 @@ function renderWithoutSSR(appData: IAppData, assets: IAssets) {
   return document;
 }
 
+// server export used in server/starters.tsx
 export { render };


### PR DESCRIPTION
Пофиксил, краш сервера в server:dev. Там странный импорт, через мидлвар, возможно лучше импортирвать напрямую, надо разбираться.
Сервер не рендерит верстку потому что асинхронная фича вложена в фичу(т.е. компонента, обернутая в withAsyncFeatures). Это ещё предстоит исправить.
например  RepositoriesSearchLayoutComponent на сервере подтягивает данные, а внутри есть Layout, соотвественно для него данных нет и рендерится null.